### PR TITLE
fix: Apply rustfmt to resolve formatting issues from PR #21

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -467,7 +467,9 @@ async fn upload_file(
         ".kml" => "kml",
         ".gpx" => "gpx",
         ".topojson" => "topojson",
-        _ => return Err(bad_request("Unsupported file type. Use .zip, .geojson, .json, .geojsonl, .kml, .gpx, or .topojson")),
+        _ => return Err(bad_request(
+            "Unsupported file type. Use .zip, .geojson, .json, .geojsonl, .kml, .gpx, or .topojson",
+        )),
     };
 
     let upload_id = create_id();

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -1517,7 +1517,10 @@ async fn test_upload_kml_lifecycle() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/uploads")
-        .header("content-type", format!("multipart/form-data; boundary={boundary}"))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
         .body(Body::from(body_data))
         .unwrap();
 
@@ -1603,7 +1606,10 @@ async fn test_upload_gpx_lifecycle() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/uploads")
-        .header("content-type", format!("multipart/form-data; boundary={boundary}"))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
         .body(Body::from(body_data))
         .unwrap();
 
@@ -1688,7 +1694,10 @@ async fn test_upload_topojson_lifecycle() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/uploads")
-        .header("content-type", format!("multipart/form-data; boundary={boundary}"))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
         .body(Body::from(body_data))
         .unwrap();
 


### PR DESCRIPTION
## 📋 Summary

This PR fixes code formatting issues introduced during the merge conflict resolution in PR #21.

## 🔧 Changes

- **backend/src/lib.rs**: Format long error message to comply with line length limits
- **backend/tests/api_tests.rs**: Format `.header()` chain calls to match project style

## ✅ Verification

```bash
# Backend tests: All 30 tests pass
cargo fmt --all
cargo clippy -- -D warnings
cargo test

# CI checks expected to pass:
# - backend_fmt ✅
# - backend_clippy ✅  
# - backend_tests ✅
```

## 📝 Context

PR #21 was successfully merged, but CI checks failed due to formatting issues in the conflict resolution. This PR applies `cargo fmt --all` to fix those issues and restore CI to green.