### PR TITLE
Fix: Feature highlight now updates immediately on click

### DIFF
--- a/docs/dev/behaviors.md
+++ b/docs/dev/behaviors.md
@@ -47,10 +47,11 @@
 | STORE-003 | 状态机 | 任务状态遵循 uploading → uploaded → processing → ready/failed 生命周期，processing 任务在重启时标记为 failed | 数据库状态转换合法，无非法转换 | `pytest test_state_machine` | Unit | P0 |
 | UI-001 | 预览可用性 | UI 仅在 status=ready 时允许打开预览，非 ready 状态（uploaded/processing/failed）禁用 | 预览按钮状态正确 | `npm run test:e2e` | E2E | P0 |
 | UI-002 | 特征检查器 | 显示基于数据集 schema 的稳定属性字段，NULL 值显示为 `--`（斜体、静音），空字符串显示为 `""`（悬停区分） | NULL 和空字符串正确区分 | `npm run test:e2e` | E2E | P0 |
-| UI-003 | 字段信息显示 | Detail Sidebar 在 status=ready 时显示"字段信息"section，列出字段名和类型，支持加载中和错误状态 | 字段信息正确显示，状态转换正确 | `npm run test:e2e` | E2E | P1 |
-| UI-004 | 登录页面 | /login 显示登录表单，验证后跳转 | 跳转成功 | `npm run test:e2e` | E2E | P0 |
-| UI-005 | 首次设置 | /init 显示管理员创建表单 | 表单可提交 | `npm run test:e2e` | E2E | P0 |
-| UI-006 | 路由守卫 | 未认证访问受保护路由跳转登录页 | 自动跳转 | `npm run test:e2e` | E2E | P0 |
+| UI-003 | 特征高亮 | 在预览地图中点击特征时，被选中的特征会立即以黄色高亮显示（填充：rgba(255,200,0,0.7)，描边：#ffc800，宽度4px），未选中特征保持蓝色（填充：rgba(0,128,255,0.6)，描边：#0080ff，宽度2px） | 点击后特征样式立即切换，无需缩放或移动地图 | `npm run test:e2e` | E2E | P0 |
+| UI-004 | 字段信息显示 | Detail Sidebar 在 status=ready 时显示"字段信息"section，列出字段名和类型，支持加载中和错误状态 | 字段信息正确显示，状态转换正确 | `npm run test:e2e` | E2E | P1 |
+| UI-005 | 登录页面 | /login 显示登录表单，验证后跳转 | 跳转成功 | `npm run test:e2e` | E2E | P0 |
+| UI-006 | 首次设置 | /init 显示管理员创建表单 | 表单可提交 | `npm run test:e2e` | E2E | P0 |
+| UI-007 | 路由守卫 | 未认证访问受保护路由跳转登录页 | 自动跳转 | `npm run test:e2e` | E2E | P0 |
 | E2E-001 | 完整上传（GeoJSON） | 上传 .geojson → 列表更新 → ready → 详情可访问 → 预览打开地图 | 端到端流程成功 | `npm run test:e2e` | E2E | P0 |
 | E2E-002 | 完整上传（Shapefile） | 上传 .zip（.shp/.shx/.dbf）→ 列表更新 → ready → 详情可访问 → 预览打开地图 | 端到端流程成功 | `npm run test:e2e` | E2E | P0 |
 | E2E-003 | 完整上传（GeoJSONSeq） | 上传 .geojsonl → 列表更新 → ready → schema 查询 → 瓦片端点验证成功 | 端到端流程成功 | `cargo test test_upload_geojsonseq_lifecycle` | Integration | P0 |

--- a/frontend/src/Preview.jsx
+++ b/frontend/src/Preview.jsx
@@ -16,6 +16,7 @@ export default function Preview() {
   const { id } = useParams();
   const mapElement = useRef(null);
   const mapRef = useRef(null); // Store the OL map instance
+  const vectorLayerRef = useRef(null); // Store the vector tile layer for style updates
   const [meta, setMeta] = useState(null);
   const [error, setError] = useState(null);
   const [selectedFid, setSelectedFid] = useState(null);
@@ -193,16 +194,21 @@ export default function Preview() {
 
         selectedFidRef.current = fid;
         setSelectedFid(fid);
+        // Trigger layer re-render to show highlight immediately
+        vectorLayerRef.current?.changed();
         // Load full row properties from DuckDB to ensure stable schema + NULL visibility.
         loadFeatureProperties(fid);
       } else {
         cancelPopup();
+        // Trigger layer re-render to clear highlight when clicking empty space
+        vectorLayerRef.current?.changed();
       }
     });
 
     return () => {
       olMap.setTarget(null);
       mapRef.current = null;
+      vectorLayerRef.current = null;
     };
   }, [cancelPopup, loadFeatureProperties]);
 
@@ -227,6 +233,7 @@ export default function Preview() {
       style: styleFunction,
     });
 
+    vectorLayerRef.current = vectorLayer;
     map.addLayer(vectorLayer);
 
     // 2. Fit bounds


### PR DESCRIPTION
## 修复内容
修复了预览页面中点击特征后，高亮效果需要滚动鼠标才能显示的问题。

### 问题原因
`styleFunction` 使用 `selectedFidRef` 来判断选中状态，但更新 ref 后没有触发 OpenLayers 图层重渲染。

### 解决方案
1. 新增 `vectorLayerRef` 保存 VectorTileLayer 引用
2. 点击特征后调用 `vectorLayerRef.current?.changed()` 立即触发重渲染
3. 补充 `behaviors.md` 文档，新增 UI-003 特征高亮行为契约

### 验证
- ✅ 点击特征后立即显示黄色高亮（无需滚动/缩放）
- ✅ 未选中特征保持蓝色样式
- ✅ Frontend 构建成功
- ✅ Backend 测试通过

### 相关行为契约
| ID | 可观测行为 | 验证标准 |
|---|---|---|
| UI-003 | 特征高亮 | 点击后特征样式立即切换，无需缩放或移动地图 |