### PR TITLE
ci: build multi-arch docker images on native runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -181,11 +181,22 @@ jobs:
           name: binary-${{ matrix.artifact_id }}
           path: release-assets/*.tar.gz
 
-  docker:
-    runs-on: ubuntu-latest
+  docker_build:
     needs:
       - docker_smoke
       - meta
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
 
@@ -195,6 +206,59 @@ jobs:
         run: |
           owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
           echo "name=ghcr.io/${owner_lc}/mapflow" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ github.workflow }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}-${{ matrix.arch }}
+
+      - name: Export digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.arch }}.txt"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-digest-${{ matrix.arch }}
+          path: /tmp/digests/${{ matrix.arch }}.txt
+
+  docker_manifest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs:
+      - docker_build
+      - meta
+    steps:
+      - name: Compute image name
+        id: image
+        shell: bash
+        run: |
+          owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "name=ghcr.io/${owner_lc}/mapflow" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: docker-digest-*
+          path: /tmp/digests
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -216,20 +280,30 @@ jobs:
             type=raw,value=nightly-${{ needs.meta.outputs.stamp }}
             type=raw,value=nightly-${{ needs.meta.outputs.short_sha }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create multi-arch manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${{ steps.image.outputs.name }}"
+
+          sources=""
+          for file in /tmp/digests/*/*.txt; do
+            digest="$(cat "$file")"
+            sources="${sources} ${image}@${digest}"
+          done
+
+          tags=""
+          while IFS= read -r tag; do
+            tags="${tags} --tag ${tag}"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+          docker buildx imagetools create ${tags} ${sources}
 
   github_release:
     runs-on: ubuntu-latest
     needs:
       - binaries
-      - docker
+      - docker_manifest
       - meta
     steps:
       - name: Download binary artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,9 +156,20 @@ jobs:
           name: binary-${{ matrix.artifact_id }}
           path: release-assets/*.tar.gz
 
-  docker:
-    runs-on: ubuntu-latest
+  docker_build:
     needs: docker_smoke
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
 
@@ -179,6 +190,57 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ github.workflow }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}-${{ matrix.arch }}
+
+      - name: Export digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.arch }}.txt"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-digest-${{ matrix.arch }}
+          path: /tmp/digests/${{ matrix.arch }}.txt
+
+  docker_manifest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: docker_build
+    steps:
+      - name: Compute image name
+        id: image
+        shell: bash
+        run: |
+          owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "name=ghcr.io/${owner_lc}/mapflow" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: docker-digest-*
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -188,19 +250,29 @@ jobs:
             type=ref,event=tag
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create multi-arch manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${{ steps.image.outputs.name }}"
+
+          sources=""
+          for file in /tmp/digests/*/*.txt; do
+            digest="$(cat "$file")"
+            sources="${sources} ${image}@${digest}"
+          done
+
+          tags=""
+          while IFS= read -r tag; do
+            tags="${tags} --tag ${tag}"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+          docker buildx imagetools create ${tags} ${sources}
 
   github_release:
     runs-on: ubuntu-latest
     needs:
-      - docker
+      - docker_manifest
       - binaries
     steps:
       - name: Download binary artifacts


### PR DESCRIPTION
## Summary\n- split docker publish into per-arch native builds (amd64 + arm64)\n- remove QEMU-based multi-platform build path from release/nightly workflows\n- merge per-arch image digests into multi-arch manifest tags\n- add build cache and timeout controls for docker publish jobs\n\n## Why\nThe previous single buildx multi-platform step could hang for hours under emulation.\n\n## Validation\n- pre-commit checks\n- pre-push full test suite\n