### PR TITLE
release: bundle spatial extension for offline startup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,9 +124,11 @@ jobs:
           - os: ubuntu-latest
             rust_target: x86_64-unknown-linux-gnu
             artifact_id: linux-amd64
+            duckdb_platform: linux_amd64
           - os: macos-14
             rust_target: aarch64-apple-darwin
             artifact_id: darwin-arm64
+            duckdb_platform: osx_arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -169,10 +171,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
+          spatial_ext_path="release-assets/spatial.duckdb_extension"
+          bash scripts/release/spatial_extension_artifact.sh download \
+            "${{ matrix.duckdb_platform }}" \
+            "${spatial_ext_path}"
           bash scripts/release/package_bundle.sh \
             "${{ needs.meta.outputs.release_version }}" \
             "${{ matrix.artifact_id }}" \
             "target/${{ matrix.rust_target }}/release/backend" \
+            "${spatial_ext_path}" \
             "release-assets"
 
       - name: Upload binary bundle
@@ -192,9 +199,11 @@ jobs:
           - arch: amd64
             platform: linux/amd64
             runner: ubuntu-latest
+            duckdb_platform: linux_amd64
           - arch: arm64
             platform: linux/arm64
             runner: ubuntu-24.04-arm
+            duckdb_platform: linux_arm64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 75
     steps:
@@ -217,12 +226,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve spatial extension archive
+        id: spatial
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="$(bash scripts/release/spatial_extension_artifact.sh url "${{ matrix.duckdb_platform }}")"
+          echo "archive_url=${url}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          build-args: |
+            SPATIAL_EXTENSION_ARCHIVE_URL=${{ steps.spatial.outputs.archive_url }}
           outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ github.workflow }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ github.workflow }}-${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,9 +98,11 @@ jobs:
           - os: ubuntu-latest
             rust_target: x86_64-unknown-linux-gnu
             artifact_id: linux-amd64
+            duckdb_platform: linux_amd64
           - os: macos-14
             rust_target: aarch64-apple-darwin
             artifact_id: darwin-arm64
+            duckdb_platform: osx_arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -144,10 +146,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
+          spatial_ext_path="release-assets/spatial.duckdb_extension"
+          bash scripts/release/spatial_extension_artifact.sh download \
+            "${{ matrix.duckdb_platform }}" \
+            "${spatial_ext_path}"
           bash scripts/release/package_bundle.sh \
             "${{ github.ref_name }}" \
             "${{ matrix.artifact_id }}" \
             "target/${{ matrix.rust_target }}/release/backend" \
+            "${spatial_ext_path}" \
             "release-assets"
 
       - name: Upload binary bundle
@@ -165,9 +172,11 @@ jobs:
           - arch: amd64
             platform: linux/amd64
             runner: ubuntu-latest
+            duckdb_platform: linux_amd64
           - arch: arm64
             platform: linux/arm64
             runner: ubuntu-24.04-arm
+            duckdb_platform: linux_arm64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 75
     steps:
@@ -190,12 +199,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve spatial extension archive
+        id: spatial
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="$(bash scripts/release/spatial_extension_artifact.sh url "${{ matrix.duckdb_platform }}")"
+          echo "archive_url=${url}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          build-args: |
+            SPATIAL_EXTENSION_ARCHIVE_URL=${{ steps.spatial.outputs.archive_url }}
           outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ github.workflow }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ github.workflow }}-${{ matrix.arch }}

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ License: Apache-2.0
 Each binary bundle contains:
 - `mapflow` backend executable
 - prebuilt frontend (`dist/`)
+- offline spatial extension binary (`extensions/spatial.duckdb_extension`)
 - `spatial-extension-manifest.json`
 
 ## Quickstart (Docker)
 
 Prerequisites: Docker + Docker Compose v2.
+
+Published images already contain `spatial.duckdb_extension`, so offline startup does not require runtime download.
 
 Run stable:
 
@@ -51,6 +54,8 @@ docker compose -f docker-compose.ghcr.yml down
 ```bash
 ./mapflow
 ```
+
+Binary bundles include `extensions/spatial.duckdb_extension` and load it automatically by default.
 
 Optional runtime config:
 

--- a/docs/dev/behaviors.md
+++ b/docs/dev/behaviors.md
@@ -76,6 +76,7 @@
 | CI-001 | 冒烟测试 | 构建 Docker → 上传 GeoJSON → 等待 ready → 获取瓦片 | 与 testdata/smoke/expected_sample_z0_x0_y0.mvt.base64 比较字节 | `scripts/ci/smoke_test.sh` | Integration | P0 |
 | CI-002 | Nightly 发布 | Nightly 工作流每日触发，先执行 verify + smoke，再发布二进制 bundle 和 GHCR nightly 镜像标签 | 生成 prerelease，包含 Linux/macOS bundle；镜像标签包含 nightly、日期、sha | `.github/workflows/nightly.yml` | Delivery | P1 |
 | CI-003 | Stable 发布 | `v*` tag 工作流先执行 verify + smoke，再发布二进制 bundle 和 GHCR stable 镜像标签 | 生成 release，包含 Linux/macOS bundle；镜像标签包含版本号和 latest | `.github/workflows/release.yml` | Delivery | P1 |
+| CI-004 | 离线扩展打包 | 发布流程按目标平台下载 DuckDB spatial extension 并写入 Docker 镜像与二进制 bundle | 镜像内存在 `/app/extensions/spatial.duckdb_extension`；bundle 内存在 `extensions/spatial.duckdb_extension` | `scripts/release/spatial_extension_artifact.sh` | Delivery | P1 |
 | OSM-001 | 瓦片生成（lines） | OSM sf_lines（20,898 道路特征）数据集生成正确瓦片（z=0,10,14 各 5 个样本） | 特征计数匹配 golden 配置 | `cargo test test_tile_golden_osm_lines_samples` | Integration | P1 |
 | OSM-002 | 瓦片生成（points） | OSM sf_points（交通信号灯、地点）数据集生成正确瓦片（z=0,10,14 各 5 个样本） | 特征计数匹配 golden 配置 | `cargo test test_tile_golden_osm_points_samples` | Integration | P1 |
 | OSM-003 | 瓦片生成（polygons） | OSM sf_polygons（31,715 建筑/土地利用特征，MultiPolygon几何）数据集生成正确瓦片（z=0,10,14 各 5 个样本） | 特征计数匹配 golden 配置 | `cargo test test_tile_golden_osm_polygons_samples` | Integration | P1 |

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -29,3 +29,4 @@ Axum 0.8, axum-login, tower-sessions, DuckDB, OpenLayers
 
 - Stable：`v*` tag 触发，发布 GHCR 多架构镜像与二进制 bundle 资产
 - Nightly：每日 UTC 02:00 自动触发（也支持手动触发），发布 prerelease 与 nightly 镜像标签
+- 发布产物内置 `spatial.duckdb_extension`（按目标平台打包），支持离线启动

--- a/scripts/release/package_bundle.sh
+++ b/scripts/release/package_bundle.sh
@@ -2,15 +2,16 @@
 
 set -euo pipefail
 
-if [ "$#" -ne 4 ]; then
-  echo "usage: $0 <version> <artifact-id> <binary-path> <output-dir>" >&2
+if [ "$#" -ne 5 ]; then
+  echo "usage: $0 <version> <artifact-id> <binary-path> <extension-path> <output-dir>" >&2
   exit 1
 fi
 
 version="$1"
 artifact_id="$2"
 binary_path="$3"
-output_dir="$4"
+extension_path="$4"
+output_dir="$5"
 
 if [ ! -f "$binary_path" ]; then
   echo "binary not found: $binary_path" >&2
@@ -22,13 +23,19 @@ if [ ! -d "frontend/dist" ]; then
   exit 1
 fi
 
+if [ ! -f "$extension_path" ]; then
+  echo "spatial extension not found: $extension_path" >&2
+  exit 1
+fi
+
 bundle_name="mapflow-${version}-${artifact_id}"
 bundle_dir="$(mktemp -d)/${bundle_name}"
-mkdir -p "${bundle_dir}"
+mkdir -p "${bundle_dir}/extensions"
 
 cp "$binary_path" "${bundle_dir}/mapflow"
 chmod +x "${bundle_dir}/mapflow"
 cp -R frontend/dist "${bundle_dir}/dist"
+cp "$extension_path" "${bundle_dir}/extensions/spatial.duckdb_extension"
 cp backend/extensions/spatial-extension-manifest.json "${bundle_dir}/spatial-extension-manifest.json"
 cp README.md "${bundle_dir}/README.md"
 cp LICENSE "${bundle_dir}/LICENSE"

--- a/scripts/release/spatial_extension_artifact.sh
+++ b/scripts/release/spatial_extension_artifact.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage:" >&2
+  echo "  $0 url <platform>" >&2
+  echo "  $0 download <platform> <output-path>" >&2
+  exit 1
+fi
+
+mode="$1"
+platform="$2"
+manifest_path="backend/extensions/spatial-extension-manifest.json"
+
+if [ ! -f "$manifest_path" ]; then
+  echo "manifest not found: $manifest_path" >&2
+  exit 1
+fi
+
+archive_url="$(
+  python3 - "$manifest_path" "$platform" <<'PY'
+import json
+import sys
+
+manifest_path = sys.argv[1]
+platform = sys.argv[2]
+
+manifest = json.load(open(manifest_path, encoding="utf-8"))
+artifacts = manifest.get("artifacts", [])
+
+for artifact in artifacts:
+    if artifact.get("platform") == platform:
+        url = artifact.get("archive_url")
+        if not url:
+            print(f"artifact '{platform}' missing archive_url", file=sys.stderr)
+            raise SystemExit(1)
+        print(url)
+        raise SystemExit(0)
+
+print(f"platform not found in manifest: {platform}", file=sys.stderr)
+raise SystemExit(1)
+PY
+)"
+
+case "$mode" in
+  url)
+    echo "$archive_url"
+    ;;
+  download)
+    if [ "$#" -ne 3 ]; then
+      echo "usage: $0 download <platform> <output-path>" >&2
+      exit 1
+    fi
+
+    output_path="$3"
+    output_dir="$(dirname "$output_path")"
+    mkdir -p "$output_dir"
+
+    tmp_gz="$(mktemp)"
+    curl -fsSL "$archive_url" -o "$tmp_gz"
+    gunzip -c "$tmp_gz" > "$output_path"
+    rm -f "$tmp_gz"
+    chmod 0644 "$output_path"
+    ;;
+  *)
+    echo "unsupported mode: $mode" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary\n- add reusable script to resolve/download DuckDB spatial extension artifact by platform\n- include platform-matched spatial extension in binary release bundles\n- include platform-matched spatial extension in Docker release images at build time\n- wire release/nightly workflows to fetch extension from manifest-driven URL\n- update docs for offline startup expectations\n\n## Validation\n- bash syntax checks\n- workflow YAML parse checks\n- package script smoke check (bundle contains extensions/spatial.duckdb_extension)\n- pre-commit + pre-push full suite\n