### PR TITLE
fix: avoid docker build failure when spatial build-arg is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve spatial extension archive
+        id: spatial
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="$(bash scripts/release/spatial_extension_artifact.sh url linux_amd64)"
+          echo "archive_url=${url}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -146,6 +154,8 @@ jobs:
           context: .
           load: true
           platforms: linux/amd64
+          build-args: |
+            SPATIAL_EXTENSION_ARCHIVE_URL=${{ steps.spatial.outputs.archive_url }}
           tags: mapflow-smoke:ci
 
       - name: Smoke test container (golden tile)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,6 +99,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve spatial extension archive
+        id: spatial
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="$(bash scripts/release/spatial_extension_artifact.sh url linux_amd64)"
+          echo "archive_url=${url}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -108,6 +116,8 @@ jobs:
           context: .
           load: true
           platforms: linux/amd64
+          build-args: |
+            SPATIAL_EXTENSION_ARCHIVE_URL=${{ steps.spatial.outputs.archive_url }}
           tags: mapflow-smoke:nightly
 
       - name: Smoke test container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve spatial extension archive
+        id: spatial
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="$(bash scripts/release/spatial_extension_artifact.sh url linux_amd64)"
+          echo "archive_url=${url}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -83,6 +91,8 @@ jobs:
           context: .
           load: true
           platforms: linux/amd64
+          build-args: |
+            SPATIAL_EXTENSION_ARCHIVE_URL=${{ steps.spatial.outputs.archive_url }}
           tags: mapflow-smoke:${{ github.ref_name }}
 
       - name: Smoke test container


### PR DESCRIPTION
## Summary
- make Dockerfile spatial extension download resilient when `SPATIAL_EXTENSION_ARCHIVE_URL` is not provided
- auto-resolve fallback URL from `spatial-extension-manifest.json` + `TARGETARCH`
- pass explicit spatial build-arg in `docker_smoke` jobs (ci/release/nightly)

## Why
Recent runs failed at Dockerfile runtime stage with `test -n "${SPATIAL_EXTENSION_ARCHIVE_URL}"` when smoke/local builds omitted the arg.

## Validation
- workflow YAML parse
- script syntax checks
- pre-commit and pre-push full test suite
