### PR TITLE
feat: add /health endpoint for service health check

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -109,6 +109,7 @@ fn build_api_router_with_auth(state: AppState, with_auth: bool) -> Router {
 
     let auth_router = build_auth_router();
     let public_router = Router::new()
+        .route("/health", get(health_check))
         .route("/api/test/is-initialized", get(check_is_initialized))
         .route("/tiles/{slug}/{z}/{x}/{y}", get(get_public_tile));
 
@@ -852,6 +853,10 @@ async fn upload_file(
     };
 
     Ok((StatusCode::CREATED, Json(meta)))
+}
+
+async fn health_check() -> impl IntoResponse {
+    (StatusCode::OK, Json(serde_json::json!({ "status": "ok" })))
 }
 
 async fn check_is_initialized(State(state): State<AppState>) -> impl IntoResponse {

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -3358,3 +3358,22 @@ async fn test_mbtiles_publish_and_public_tiles() {
         .and_then(|v| v.to_str().ok());
     assert_eq!(content_type, Some("application/vnd.mapbox-vector-tile"));
 }
+
+#[tokio::test]
+async fn test_health_check() {
+    let (app, _temp) = setup_app().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(body_json["status"], "ok");
+}

--- a/docs/dev/behaviors.md
+++ b/docs/dev/behaviors.md
@@ -44,6 +44,9 @@
 | API-009 | 公开地址 | GET /api/files/:id/public-url 需要认证，返回当前文件的公开 URL 模板 | 200 + `{slug,url}` / 401 / 404 | `cargo test test_public_url_*` | Integration | P1 |
 | API-010 | 公开瓦片 | GET /tiles/:slug/:z/:x/:y **无需认证**，验证 `public_slug` 存在且 `is_public=TRUE`。动态生成返回 MVT；MBTiles 返回 MVT 或 PNG（取决于 tile_format） | 200 + MVT/PNG / 204 / 400 / 404 | `cargo test test_public_tiles_*` | Integration | P0 |
 | API-011 | 测试端点 | POST /api/test/reset 重置数据库和存储，仅在 debug + MAPFLOW_TEST_MODE=1 | 执行成功，仅在 debug 构建 | `cargo test test_reset` | Integration | P2 |
+| API-012 | 公开PMTiles | GET /tiles/:slug **无需认证**，PMTiles HTTP Range 代理。处理 Range 请求头，返回对应字节范围。支持 `HEAD` 检测文件大小。PMTiles 格式单文件包含所有瓦片和元数据 | 206（Partial Content）/ 200（HEAD）/ 404 / 416（Range Invalid） | 手动测试 | Integration | P0 |
+| API-013 | 公开瓦片元数据 | GET /tiles/:slug/meta **无需认证**，返回公开瓦片的元数据（name, tile_source, tile_url, viewer_url）用于前端判断使用哪种瓦片源 | 200 + `{slug,name,tile_source,tile_url,viewer_url}` / 404 | 手动测试 | Integration | P0 |
+| API-014 | 健康检查 | GET /health **无需认证**，返回服务状态 | 200 + `{status:"ok"}` | `cargo test test_health_check` | Integration | P2 |
 | AUTH-001 | 首次设置 | POST /api/auth/init 创建初始管理员 | 200 / 400 / 409 / 500 | `npm run test:e2e` | E2E | P0 |
 | AUTH-002 | 登录 | POST /api/auth/login 验证凭证，设置会话 | 200 / 401 / 500 | `npm run test:e2e` | E2E | P0 |
 | AUTH-003 | 登出 | POST /api/auth/logout 清除会话 | 204 / 500 | `npm run test:e2e` | E2E | P0 |


### PR DESCRIPTION
## Summary

- Add `GET /health` endpoint for service health monitoring
- Returns `{"status":"ok"}` without requiring authentication
- Useful for load balancers, Kubernetes probes, and monitoring systems

## Changes

- `backend/src/lib.rs`: Add route and handler
- `backend/tests/api_tests.rs`: Add integration test
- `docs/dev/behaviors.md`: Add API-014 contract

## Test Plan

- [x] `cargo test test_health_check` passes
- [x] All existing tests pass (59 tests)
- [x] Clippy check passes