### PR TITLE
feat: extract utility functions and add unit tests

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import {
   mergeServerFilesWithOptimistic,
 } from './polling.js';
 import { publishFile, unpublishFile } from './api.js';
+import { formatSize, parseType, validateSlug } from './utils.js';
 
 function PublishModal({ file, onClose, onSuccess }) {
   const [slug, setSlug] = useState(file?.id || '');
@@ -40,12 +41,7 @@ function PublishModal({ file, onClose, onSuccess }) {
   const previewUrl = trimmedSlug
     ? `/tiles/${trimmedSlug}/{z}/{x}/{y}`
     : `/tiles/${file.id}/{z}/{x}/{y}`;
-  const slugError =
-    trimmedSlug.length > 100
-      ? 'URL 标识不能超过 100 个字符'
-      : trimmedSlug && !/^[a-zA-Z0-9_-]+$/.test(trimmedSlug)
-        ? '仅支持字母、数字、连字符和下划线'
-        : '';
+  const { error: slugError } = validateSlug(trimmedSlug);
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -110,26 +106,6 @@ const STATUS_LABELS = {
   ready: '已就绪',
   failed: '失败',
 };
-
-function formatSize(bytes) {
-  if (bytes === 0) return '0 B';
-  const units = ['B', 'KB', 'MB', 'GB'];
-  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const value = bytes / Math.pow(1024, index);
-  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[index]}`;
-}
-
-function parseType(fileName) {
-  const lower = fileName.toLowerCase();
-  if (lower.endsWith('.zip')) return 'shapefile';
-  if (lower.endsWith('.geojson') || lower.endsWith('.json')) return 'geojson';
-  if (lower.endsWith('.geojsonl') || lower.endsWith('.geojsons')) return 'geojsonl';
-  if (lower.endsWith('.kml')) return 'kml';
-  if (lower.endsWith('.gpx')) return 'gpx';
-  if (lower.endsWith('.topojson')) return 'topojson';
-  if (lower.endsWith('.mbtiles')) return 'mbtiles';
-  return 'unknown';
-}
 
 function DetailSidebar({ file }) {
   const [schema, setSchema] = useState(null);

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,0 +1,28 @@
+export function formatSize(bytes) {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, index);
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[index]}`;
+}
+
+export function parseType(fileName) {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith('.zip')) return 'shapefile';
+  if (lower.endsWith('.geojson') || lower.endsWith('.json')) return 'geojson';
+  if (lower.endsWith('.geojsonl') || lower.endsWith('.geojsons')) return 'geojsonl';
+  if (lower.endsWith('.kml')) return 'kml';
+  if (lower.endsWith('.gpx')) return 'gpx';
+  if (lower.endsWith('.topojson')) return 'topojson';
+  if (lower.endsWith('.mbtiles')) return 'mbtiles';
+  return 'unknown';
+}
+
+export function validateSlug(slug) {
+  if (!slug) return { valid: true, error: '' };
+  if (slug.length > 100) return { valid: false, error: 'URL 标识不能超过 100 个字符' };
+  if (!/^[a-zA-Z0-9_-]+$/.test(slug)) {
+    return { valid: false, error: '仅支持字母、数字、连字符和下划线' };
+  }
+  return { valid: true, error: '' };
+}

--- a/frontend/tests/unit/utils.test.js
+++ b/frontend/tests/unit/utils.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatSize, parseType, validateSlug } from '../../src/utils.js';
+
+describe('formatSize', () => {
+  it('formats 0 bytes', () => {
+    expect(formatSize(0)).toBe('0 B');
+  });
+
+  it('formats bytes', () => {
+    expect(formatSize(100)).toBe('100 B');
+    expect(formatSize(1023)).toBe('1023 B');
+  });
+
+  it('formats kilobytes', () => {
+    expect(formatSize(1024)).toBe('1.0 KB');
+    expect(formatSize(1536)).toBe('1.5 KB');
+    expect(formatSize(10240)).toBe('10 KB');
+  });
+
+  it('formats megabytes', () => {
+    expect(formatSize(1048576)).toBe('1.0 MB');
+    expect(formatSize(10485760)).toBe('10 MB');
+  });
+
+  it('formats gigabytes', () => {
+    expect(formatSize(1073741824)).toBe('1.0 GB');
+    expect(formatSize(10737418240)).toBe('10 GB');
+  });
+});
+
+describe('parseType', () => {
+  it('recognizes shapefile', () => {
+    expect(parseType('data.zip')).toBe('shapefile');
+    expect(parseType('DATA.ZIP')).toBe('shapefile');
+  });
+
+  it('recognizes geojson', () => {
+    expect(parseType('data.geojson')).toBe('geojson');
+    expect(parseType('data.json')).toBe('geojson');
+    expect(parseType('DATA.GEOJSON')).toBe('geojson');
+  });
+
+  it('recognizes geojsonl', () => {
+    expect(parseType('data.geojsonl')).toBe('geojsonl');
+    expect(parseType('data.geojsons')).toBe('geojsonl');
+  });
+
+  it('recognizes kml', () => {
+    expect(parseType('data.kml')).toBe('kml');
+  });
+
+  it('recognizes gpx', () => {
+    expect(parseType('data.gpx')).toBe('gpx');
+  });
+
+  it('recognizes topojson', () => {
+    expect(parseType('data.topojson')).toBe('topojson');
+  });
+
+  it('recognizes mbtiles', () => {
+    expect(parseType('data.mbtiles')).toBe('mbtiles');
+  });
+
+  it('returns unknown for unrecognized extensions', () => {
+    expect(parseType('data.txt')).toBe('unknown');
+    expect(parseType('data')).toBe('unknown');
+  });
+});
+
+describe('validateSlug', () => {
+  it('accepts empty slug', () => {
+    expect(validateSlug('')).toEqual({ valid: true, error: '' });
+  });
+
+  it('accepts valid slugs', () => {
+    expect(validateSlug('my-map')).toEqual({ valid: true, error: '' });
+    expect(validateSlug('my_map')).toEqual({ valid: true, error: '' });
+    expect(validateSlug('map123')).toEqual({ valid: true, error: '' });
+    expect(validateSlug('ABC')).toEqual({ valid: true, error: '' });
+    expect(validateSlug('a')).toEqual({ valid: true, error: '' });
+  });
+
+  it('rejects slug longer than 100 characters', () => {
+    const longSlug = 'a'.repeat(101);
+    expect(validateSlug(longSlug)).toEqual({
+      valid: false,
+      error: 'URL 标识不能超过 100 个字符',
+    });
+  });
+
+  it('accepts slug exactly 100 characters', () => {
+    const maxSlug = 'a'.repeat(100);
+    expect(validateSlug(maxSlug)).toEqual({ valid: true, error: '' });
+  });
+
+  it('rejects slug with invalid characters', () => {
+    expect(validateSlug('my map')).toEqual({
+      valid: false,
+      error: '仅支持字母、数字、连字符和下划线',
+    });
+    expect(validateSlug('my.map')).toEqual({
+      valid: false,
+      error: '仅支持字母、数字、连字符和下划线',
+    });
+    expect(validateSlug('my/map')).toEqual({
+      valid: false,
+      error: '仅支持字母、数字、连字符和下划线',
+    });
+    expect(validateSlug('my!map')).toEqual({
+      valid: false,
+      error: '仅支持字母、数字、连字符和下划线',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `formatSize`, `parseType`, `validateSlug` to `utils.js`
- Refactor `PublishModal` to use extracted `validateSlug`
- Add comprehensive unit tests for `utils.js`

## Changes

- `frontend/src/utils.js`: New file with extracted utility functions
- `frontend/src/App.jsx`: Import from utils.js, remove inline definitions
- `frontend/tests/unit/utils.test.js`: 18 new tests

## Test Plan

- [x] All unit tests pass (26 tests total, up from 8)
- [x] Frontend build succeeds
- [x] Backend tests unaffected