### PR TITLE
chore: add CODEOWNERS for auto-assigning reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS - Auto-assign reviewers
+
+# Default owners
+* @sharkAndshark @evan-zhang11
+
+# Backend Rust code
+/backend/ @evan-zhang11
+
+# Frontend code  
+/frontend/ @evan-zhang11
+
+# CI/CD workflows
+/.github/workflows/ @evan-zhang11
+
+# Documentation
+/docs/ @sharkAndshark @evan-zhang11
+*.md @sharkAndshark @evan-zhang11


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file to automatically assign reviewers
- Assign @evan-zhang11 as owner for backend, frontend, and CI/CD
- Both @sharkAndshark and @evan-zhang11 own documentation

This ensures maintainers get notified automatically for relevant changes.