### PR TITLE
fix: resolve persistence test flakiness by explicit drop

### DIFF
--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -1315,7 +1315,6 @@ async fn test_upload_shapefile_zip_lifecycle() {
 }
 
 #[tokio::test]
-#[ignore = "flaky: DuckDB WAL replay internal error"]
 async fn test_persistence_across_restart_keeps_ready_dataset() {
     let temp_dir = TempDir::new().expect("temp dir");
     let upload_dir = temp_dir.path().join("uploads");
@@ -1360,6 +1359,8 @@ async fn test_persistence_across_restart_keeps_ready_dataset() {
 
     let ready_item = wait_until_ready(&app1, &file_id).await;
     assert_eq!(ready_item.status, "ready");
+
+    drop(app1);
 
     // Simulate restart: new DB connection and router, same DB file + upload dir.
     let conn2 = init_database(&db_path);

--- a/docs/dev/todo.md
+++ b/docs/dev/todo.md
@@ -2,26 +2,6 @@
 
 **Last Updated**: 2026-02-16
 
-## Test Bugs (Needs Fix)
-
-### test_persistence_across_restart_keeps_ready_dataset
-
-- **Location**: `backend/tests/api_tests.rs`
-- **Status**: `#[ignore]`
-- **Root Cause**: 测试代码 bug - 创建 conn2 时 conn1 仍未关闭
-- **Analysis**:
-  - `app1` 和 `db1` 在整个测试函数作用域内都存活
-  - 创建 `conn2` 时，`conn1` 仍持有数据库连接
-  - DuckDB 在多连接场景下 WAL replay 出问题
-- **Fix Options**:
-  1. 显式 `drop(app1)` 和 `drop(db1)` 后再创建 conn2
-  2. 在 conn1 上执行 `CHECKPOINT` 强制 flush WAL
-- **Related DuckDB Issues**:
-  - https://github.com/duckdb/duckdb/issues/20543
-  - https://github.com/duckdb/duckdb/issues/19712
-  - https://github.com/duckdb/duckdb/issues/18259
-- **Priority**: Low (persistence 测试对当前功能影响较小)
-
 ## Performance Improvements
 
 ### Docker Build Time (docker_smoke)


### PR DESCRIPTION
## Summary

- Fixed flaky `test_persistence_across_restart_keeps_ready_dataset` test by adding explicit `drop(app1)` before creating the second database connection
- Removed `#[ignore]` attribute from the test
- Updated `docs/dev/todo.md` to remove the resolved bug entry

## Details

The test was failing due to DuckDB WAL replay issues when opening a second connection while the first was still active. The fix properly simulates a restart by explicitly dropping `app1` before creating `conn2`, ensuring all references to the first database connection are released.

**Before:**
```rust
let ready_item = wait_until_ready(&app1, &file_id).await;
assert_eq!(ready_item.status, "ready");

// Simulate restart: new DB connection...
let conn2 = init_database(&db_path);
```

**After:**
```rust
let ready_item = wait_until_ready(&app1, &file_id).await;
assert_eq!(ready_item.status, "ready");

drop(app1);

// Simulate restart: new DB connection...
let conn2 = init_database(&db_path);
```