### PR TITLE
feat(mbtiles): add connection pool with moka cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "flate2",
  "hex",
  "http-body-util",
+ "moka",
  "mvt-reader",
  "rand 0.8.5",
  "regex",
@@ -676,6 +677,30 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1589,6 +1614,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1817,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2560,6 +2608,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -26,6 +26,7 @@ time = "0.3"
 async-trait = "0.1"
 thiserror = "2.0"
 rusqlite = { version = "0.32", features = ["bundled"] }
+moka = { version = "0.12", features = ["sync"] }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -436,7 +436,7 @@ pub async fn get_file_schema(
         drop(conn);
         if format == "mvt" {
             let full_path = mbtiles::resolve_mbtiles_path(&file_path);
-            match mbtiles::extract_mbtiles_layers(&full_path) {
+            match mbtiles::extract_mbtiles_layers_async(&full_path).await {
                 Ok(layers) => {
                     return Ok(Json(crate::models::FileSchemaResponse { layers }));
                 }

--- a/backend/src/mbtiles.rs
+++ b/backend/src/mbtiles.rs
@@ -11,15 +11,37 @@
 //! - Bounds are stored in WGS84 (EPSG:4326) per MBTiles spec
 //! - Tiles are in Web Mercator (EPSG:3857) projection
 
+use moka::sync::Cache;
 use rusqlite::{Connection, OptionalExtension};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+type ConnCache = Cache<PathBuf, Arc<Mutex<Connection>>>;
+
+static MBTILES_CACHE: std::sync::OnceLock<ConnCache> = std::sync::OnceLock::new();
+
+fn get_cache() -> &'static ConnCache {
+    MBTILES_CACHE.get_or_init(|| Cache::builder().max_capacity(100).build())
+}
+
+fn get_cached_connection(file_path: &Path) -> Result<Arc<Mutex<Connection>>, String> {
+    let cache = get_cache();
+    let path_buf = file_path.to_path_buf();
+
+    cache
+        .try_get_with(path_buf.clone(), || {
+            Connection::open(&path_buf)
+                .map(|conn| Arc::new(Mutex::new(conn)))
+                .map_err(|e| format!("Cannot open MBTiles file: {}", e))
+        })
+        .map_err(|e| e.to_string())
+}
 
 /// Validate that a file is a valid MBTiles SQLite database
 /// with required metadata and tiles tables (or views)
 pub fn validate_mbtiles_structure(file_path: &Path) -> Result<(), String> {
     let conn = Connection::open(file_path).map_err(|e| format!("Invalid MBTiles file: {}", e))?;
 
-    // Helper function to check if table or view exists
     fn table_or_view_exists(conn: &Connection, name: &str) -> Result<bool, String> {
         conn.query_row(
             &format!(
@@ -34,16 +56,13 @@ pub fn validate_mbtiles_structure(file_path: &Path) -> Result<(), String> {
         .map_err(|e| format!("Failed to check table/view: {}", e))
     }
 
-    // Check metadata table/view exists
     let has_metadata = table_or_view_exists(&conn, "metadata")?;
     if !has_metadata {
         return Err("MBTiles file missing metadata table".to_string());
     }
 
-    // Check tiles table/view exists
     let has_tiles = table_or_view_exists(&conn, "tiles")?;
     if !has_tiles {
-        // List available tables/views for better error message
         let tables: Vec<String> = conn
             .prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'view') ORDER BY name")
             .map_err(|e| format!("Failed to prepare query: {}", e))?
@@ -60,6 +79,13 @@ pub fn validate_mbtiles_structure(file_path: &Path) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+pub async fn validate_mbtiles_structure_async(file_path: &Path) -> Result<(), String> {
+    let path = file_path.to_path_buf();
+    tokio::task::spawn_blocking(move || validate_mbtiles_structure(&path))
+        .await
+        .map_err(|e| format!("spawn_blocking error: {}", e))?
 }
 
 /// MBTiles metadata extracted from metadata table
@@ -87,7 +113,6 @@ pub fn extract_mbtiles_metadata(file_path: &Path) -> Result<MbtilesMetadata, Str
     let mut maxzoom = None;
     let mut name = None;
 
-    // Query all metadata at once (performance optimization)
     let mut stmt = conn
         .prepare("SELECT name, value FROM metadata")
         .map_err(|e| format!("Failed to prepare metadata query: {}", e))?;
@@ -107,9 +132,7 @@ pub fn extract_mbtiles_metadata(file_path: &Path) -> Result<MbtilesMetadata, Str
             "minzoom" => minzoom = value.parse().ok(),
             "maxzoom" => maxzoom = value.parse().ok(),
             "name" => name = Some(value),
-            _ => {
-                // Ignore unknown metadata keys
-            }
+            _ => {}
         }
     }
 
@@ -123,6 +146,13 @@ pub fn extract_mbtiles_metadata(file_path: &Path) -> Result<MbtilesMetadata, Str
     })
 }
 
+pub async fn extract_mbtiles_metadata_async(file_path: &Path) -> Result<MbtilesMetadata, String> {
+    let path = file_path.to_path_buf();
+    tokio::task::spawn_blocking(move || extract_mbtiles_metadata(&path))
+        .await
+        .map_err(|e| format!("spawn_blocking error: {}", e))?
+}
+
 /// Extract vector layers from MBTiles json metadata
 /// Returns list of layers with their fields
 pub fn extract_mbtiles_layers(file_path: &Path) -> Result<Vec<crate::models::LayerInfo>, String> {
@@ -130,7 +160,6 @@ pub fn extract_mbtiles_layers(file_path: &Path) -> Result<Vec<crate::models::Lay
 
     let conn = Connection::open(file_path).map_err(|e| format!("Cannot open MBTiles: {}", e))?;
 
-    // Query json metadata
     let json_metadata: Option<String> = conn
         .query_row("SELECT value FROM metadata WHERE name='json'", [], |row| {
             row.get(0)
@@ -140,11 +169,9 @@ pub fn extract_mbtiles_layers(file_path: &Path) -> Result<Vec<crate::models::Lay
 
     let json_str = json_metadata.ok_or("No json metadata found")?;
 
-    // Parse JSON
     let json_value: serde_json::Value = serde_json::from_str(&json_str)
         .map_err(|e| format!("Failed to parse json metadata: {}", e))?;
 
-    // Extract vector_layers
     let vector_layers = json_value["vector_layers"]
         .as_array()
         .ok_or("Missing vector_layers in json metadata")?;
@@ -181,6 +208,15 @@ pub fn extract_mbtiles_layers(file_path: &Path) -> Result<Vec<crate::models::Lay
     Ok(layers)
 }
 
+pub async fn extract_mbtiles_layers_async(
+    file_path: &Path,
+) -> Result<Vec<crate::models::LayerInfo>, String> {
+    let path = file_path.to_path_buf();
+    tokio::task::spawn_blocking(move || extract_mbtiles_layers(&path))
+        .await
+        .map_err(|e| format!("spawn_blocking error: {}", e))?
+}
+
 /// Import MBTiles metadata into the database
 /// This doesn't import the actual tiles - they stay in the SQLite file
 pub async fn import_mbtiles(
@@ -188,17 +224,14 @@ pub async fn import_mbtiles(
     source_id: &str,
     file_path: &Path,
 ) -> Result<(), String> {
-    let metadata = extract_mbtiles_metadata(file_path)?;
+    let metadata = extract_mbtiles_metadata_async(file_path).await?;
 
-    // Normalize format: "pbf" -> "mvt"
     let tile_format = match metadata.format.as_str() {
         "pbf" => "mvt",
         "png" | "jpg" | "jpeg" => "png",
         _ => return Err(format!("Unsupported tile format: {}", metadata.format)),
     };
 
-    // Parse bounds into JSON array
-    // MBTiles spec: bounds in WGS84 (EPSG:4326) as "minx,miny,maxx,maxy"
     let bounds_json = metadata.bounds.and_then(|b| {
         let parts: Vec<&str> = b.split(',').collect();
         if parts.len() != 4 {
@@ -230,23 +263,23 @@ pub async fn get_tile_from_mbtiles(
     x: i32,
     y: i32,
 ) -> Result<Option<Vec<u8>>, String> {
-    // Convert XYZ to TMS (MBTiles uses TMS y-coordinate)
-    // TMS y = 2^z - 1 - XYZ y
     let tms_y = (1_i32 << z) - 1 - y;
+    let path = file_path.to_path_buf();
 
-    let conn =
-        Connection::open(file_path).map_err(|e| format!("Cannot open MBTiles file: {}", e))?;
-
-    let tile_data: Option<Vec<u8>> = conn
-        .query_row(
-            "SELECT tile_data FROM tiles WHERE zoom_level = ? AND tile_column = ? AND tile_row = ?",
-            [z, x, tms_y],
-            |row| row.get(0),
-        )
-        .unwrap_or(None);
-
-    // Filter out empty tiles
-    Ok(tile_data.filter(|d| !d.is_empty()))
+    tokio::task::spawn_blocking(move || {
+        let conn = get_cached_connection(&path)?;
+        let guard = conn.lock().map_err(|e| format!("Lock poisoned: {}", e))?;
+        let tile_data: Option<Vec<u8>> = guard
+            .query_row(
+                "SELECT tile_data FROM tiles WHERE zoom_level = ? AND tile_column = ? AND tile_row = ?",
+                [z, x, tms_y],
+                |row| row.get(0),
+            )
+            .unwrap_or(None);
+        Ok(tile_data.filter(|d| !d.is_empty()))
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking error: {}", e))?
 }
 
 /// Convert a stored file path to an absolute path for MBTiles access

--- a/backend/src/upload.rs
+++ b/backend/src/upload.rs
@@ -96,7 +96,7 @@ pub async fn upload_file(
     let validation = match file_type {
         "shapefile" => crate::validation::validate_shapefile_zip(&file_path).await,
         "geojson" => crate::validation::validate_geojson(&file_path).await,
-        "mbtiles" => mbtiles::validate_mbtiles_structure(&file_path),
+        "mbtiles" => mbtiles::validate_mbtiles_structure_async(&file_path).await,
         "pmtiles" => Ok(()),
         "geojsonl" | "kml" | "gpx" | "topojson" => Ok(()),
         _ => Ok(()),

--- a/docs/dev/todo.md
+++ b/docs/dev/todo.md
@@ -14,9 +14,10 @@
 
 ### MBTiles Connection Pool
 
-- **Current**: New SQLite connection per request
-- **Goal**: Connection pooling for high-traffic scenarios
-- **Priority**: High (for production)
+- **Status**: ✅ Done (2026-02-16)
+- **Solution**: moka cache + spawn_blocking
+  - LRU cache with max 100 connections
+  - spawn_blocking to avoid blocking tokio runtime
 
 ### Slug Race Condition
 


### PR DESCRIPTION
## Summary
- Add moka LRU cache (max 100 connections) for MBTiles SQLite connections
- Wrap all sync SQLite calls with `spawn_blocking` to avoid blocking tokio runtime:
  - `get_tile_from_mbtiles` (hot path)
  - `validate_mbtiles_structure_async` (upload)
  - `extract_mbtiles_metadata_async` (import)
  - `extract_mbtiles_layers_async` (schema endpoint)
- Properly propagate errors with `try_get_with` (no panic on file open failure)

Closes MBTiles Connection Pool item in todo.md