### PR TITLE
fix(upload): use UUID for upload IDs instead of 6-char hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,6 @@ dependencies = [
  "http-body-util",
  "moka",
  "mvt-reader",
- "rand 0.9.2",
  "regex",
  "rusqlite",
  "serde",
@@ -815,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2081,7 +2080,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2349,7 +2348,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2710,7 +2709,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,7 +11,6 @@ tower-http = { version = "0.6", features = ["cors", "fs", "trace", "request-id"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-rand = "0.9"
 zip = "6.0"
 hex = "0.4"
 duckdb = { version = "1.4.4", features = ["bundled", "chrono"] }

--- a/backend/src/upload.rs
+++ b/backend/src/upload.rs
@@ -5,13 +5,13 @@ use axum::{
     Json,
 };
 use chrono::Utc;
-use rand::RngCore;
 use std::path::Path;
 use tokio::{
     fs,
     io::{AsyncWriteExt, BufWriter},
 };
 use tracing::{info_span, Instrument};
+use uuid::Uuid;
 
 use crate::{
     http_errors::{bad_request, internal_error, payload_too_large},
@@ -235,7 +235,5 @@ pub async fn upload_file(
 }
 
 fn create_id() -> String {
-    let mut bytes = [0u8; 3];
-    rand::rng().fill_bytes(&mut bytes);
-    hex::encode(bytes)
+    Uuid::new_v4().to_string()
 }


### PR DESCRIPTION
## Summary

- Replace 6-character hex IDs (~16M combinations) with UUID v4 for significantly stronger uniqueness guarantees and collision resistance
- Remove unused `rand` dependency from Cargo.toml

## Why

The previous implementation used 6-character hex IDs (3 random bytes), providing only ~16.7M unique combinations. This could lead to:
- ID enumeration attacks
- Potential collisions at scale

UUID v4 provides 122 random bits (~5.3×10³⁶ combinations), making collision practically impossible.

## Test Plan

- All 93 backend tests pass
- All 26 frontend unit tests pass  
- All 21 E2E tests pass
- Pre-push hooks: fmt ✅, clippy ✅, tests ✅