### PR TITLE
fix: use UUID for upload IDs and enable ignored test

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -124,7 +124,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "needs authentication"]
     async fn list_returns_seeded_items() {
         let (state, _temp_dir) = setup_state(1024).await;
         let uploaded_at = "2026-02-04T10:00:00Z";
@@ -166,7 +165,7 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        let app = build_api_router(state);
+        let app = build_test_router(state);
         let response = app
             .oneshot(
                 Request::builder()


### PR DESCRIPTION
## Summary
- Use UUID for upload IDs instead of 6-char hex to avoid collision risk
- Enable previously ignored `list_returns_seeded_items` test by using `build_test_router`

## Changes
1. `fix(upload): use UUID for upload IDs instead of 6-char hex` - Original fix
2. `fix(test): enable ignored test by using build_test_router` - Test fix

The test was ignored because it used `build_api_router` which requires authentication. Changed to use `build_test_router` which is designed for testing without auth, following the same pattern used in `api_tests.rs`.