### PR TITLE
feat(backend): add custom CRS support for non-EPSG coordinate systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -393,6 +393,7 @@ dependencies = [
  "flate2",
  "hex",
  "http-body-util",
+ "lazy_static",
  "moka",
  "mvt-reader",
  "regex",
@@ -410,7 +411,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "zip 8.0.0",
+ "zip",
 ]
 
 [[package]]
@@ -421,22 +422,22 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bcrypt"
-version = "0.18.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0f5948f30df5f43ac29d310b7476793be97c50787e6ef4a63d960a0d0be827"
+checksum = "e65938ed058ef47d92cf8b346cc76ef48984572ade631927e9937b5ffc7662c7"
 dependencies = [
  "base64",
  "blowfish",
- "getrandom 0.3.4",
+ "getrandom 0.2.17",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -489,7 +490,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -549,9 +550,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -625,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cookie"
@@ -727,9 +728,9 @@ checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -743,7 +744,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -765,7 +766,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -876,12 +877,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,7 +935,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1021,21 +1016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,11 +1038,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -1070,8 +1059,14 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "foldhash 0.2.0",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1081,15 +1076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1332,12 +1318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,8 +1346,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1437,12 +1415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "lexical-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,9 +1479,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libduckdb-sys"
@@ -1525,7 +1497,7 @@ dependencies = [
  "serde_json",
  "tar",
  "vcpkg",
- "zip 6.0.0",
+ "zip",
 ]
 
 [[package]]
@@ -1542,14 +1514,14 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall 0.7.1",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1592,9 +1564,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.16.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d673a11333485e7d8b93d62a9a5b07b22daf5e8a8655a44c1bb18aa4bf3d1524"
+checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
 dependencies = [
  "crc",
  "sha2",
@@ -1915,7 +1887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1971,7 +1943,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types",
  "regex",
- "syn 2.0.115",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -1985,7 +1957,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1998,7 +1970,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2176,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]
@@ -2305,28 +2277,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
-dependencies = [
- "hashbrown 0.16.1",
- "thiserror",
-]
-
-[[package]]
 name = "rusqlite"
-version = "0.38.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.11.0",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -2407,9 +2368,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "scopeguard"
@@ -2422,12 +2383,6 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2456,7 +2411,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2596,18 +2551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
-dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,7 +2581,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2650,7 +2593,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2672,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2698,7 +2641,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2726,12 +2669,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2754,7 +2697,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2774,7 +2717,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2857,7 +2799,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2906,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.8+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
@@ -3057,7 +2999,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3106,12 +3048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typed-path"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,21 +3061,15 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3173,11 +3103,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3221,15 +3151,6 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3280,7 +3201,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -3291,40 +3212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -3377,7 +3264,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3388,7 +3275,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3585,88 +3472,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.115",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.115",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3712,7 +3517,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -3733,7 +3538,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3753,7 +3558,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -3774,7 +3579,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3807,7 +3612,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3816,27 +3621,14 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap",
- "memchr",
- "zopfli",
-]
-
-[[package]]
-name = "zip"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b32dd4ad3aca14ae109f8cce0495ac1c57f6f4f00ad459a40e582f89440d97"
-dependencies = [
  "aes",
+ "arbitrary",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "hmac",
  "indexmap",
  "lzma-rust2",
@@ -3845,7 +3637,6 @@ dependencies = [
  "ppmd-rust",
  "sha1",
  "time",
- "typed-path",
  "zeroize",
  "zopfli",
  "zstd",
@@ -3859,9 +3650,9 @@ checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zopfli"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -17,6 +17,7 @@ duckdb = { version = "1.4.4", features = ["bundled", "chrono"] }
 axum-extra = { version = "0.12.5", features = ["query"] }
 bcrypt = "0.18"
 regex = "1.10"
+lazy_static = "1.5"
 uuid = { version = "1.11", features = ["v4", "serde"] }
 axum-login = "0.18"
 tower-sessions = "0.14"

--- a/backend/src/crs.rs
+++ b/backend/src/crs.rs
@@ -1,0 +1,284 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+
+pub const CRS_TYPE_STANDARD: &str = "standard";
+pub const CRS_TYPE_CUSTOM: &str = "custom";
+
+lazy_static! {
+    static ref EPSG_PATTERN: Regex = Regex::new(r"(?i)^EPSG:(\d+)$").unwrap();
+    static ref WGS84_ALIASES: Vec<&'static str> = vec![
+        "WGS84",
+        "WGS_1984",
+        "CRS84",
+        "urn:ogc:def:crs:OGC:1.3:CRS84"
+    ];
+    static ref AUTHORITY_EPSG_PATTERN: Regex =
+        Regex::new(r#"AUTHORITY\s*\[\s*"EPSG"\s*,\s*"(\d+)"\s*\]"#).unwrap();
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizedCrs {
+    pub crs: Option<String>,
+    pub crs_type: String,
+}
+
+pub fn normalize_crs(raw: Option<&str>) -> NormalizedCrs {
+    match raw {
+        None => NormalizedCrs {
+            crs: None,
+            crs_type: CRS_TYPE_CUSTOM.to_string(),
+        },
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return NormalizedCrs {
+                    crs: None,
+                    crs_type: CRS_TYPE_CUSTOM.to_string(),
+                };
+            }
+
+            if let Some(caps) = EPSG_PATTERN.captures(trimmed) {
+                let code: &str = caps.get(1).unwrap().as_str();
+                return NormalizedCrs {
+                    crs: Some(format!("EPSG:{}", code)),
+                    crs_type: CRS_TYPE_STANDARD.to_string(),
+                };
+            }
+
+            if WGS84_ALIASES
+                .iter()
+                .any(|alias| trimmed.eq_ignore_ascii_case(alias))
+            {
+                return NormalizedCrs {
+                    crs: Some("EPSG:4326".to_string()),
+                    crs_type: CRS_TYPE_STANDARD.to_string(),
+                };
+            }
+
+            if trimmed.starts_with("PROJCS") || trimmed.starts_with("GEOGCS") {
+                return parse_wkt(trimmed);
+            }
+
+            NormalizedCrs {
+                crs: Some(trimmed.to_string()),
+                crs_type: CRS_TYPE_CUSTOM.to_string(),
+            }
+        }
+    }
+}
+
+fn parse_wkt(wkt: &str) -> NormalizedCrs {
+    if let Some(caps) = AUTHORITY_EPSG_PATTERN.captures(wkt) {
+        let code: &str = caps.get(1).unwrap().as_str();
+        NormalizedCrs {
+            crs: Some(format!("EPSG:{}", code)),
+            crs_type: CRS_TYPE_STANDARD.to_string(),
+        }
+    } else {
+        NormalizedCrs {
+            crs: Some(wkt.to_string()),
+            crs_type: CRS_TYPE_CUSTOM.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DataBounds {
+    pub minx: f64,
+    pub miny: f64,
+    pub maxx: f64,
+    pub maxy: f64,
+}
+
+impl DataBounds {
+    pub fn to_json(self) -> String {
+        format!(
+            r#"{{"minx":{},"miny":{},"maxx":{},"maxy":{}}}"#,
+            self.minx, self.miny, self.maxx, self.maxy
+        )
+    }
+
+    pub fn from_json(json: &str) -> Option<Self> {
+        let v: serde_json::Value = serde_json::from_str(json).ok()?;
+        Some(DataBounds {
+            minx: v.get("minx")?.as_f64()?,
+            miny: v.get("miny")?.as_f64()?,
+            maxx: v.get("maxx")?.as_f64()?,
+            maxy: v.get("maxy")?.as_f64()?,
+        })
+    }
+
+    pub fn to_array(self) -> [f64; 4] {
+        [self.minx, self.miny, self.maxx, self.maxy]
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.maxx > self.minx && self.maxy > self.miny
+    }
+}
+
+pub fn calculate_custom_tile_bbox(
+    bounds: &DataBounds,
+    z: i32,
+    x: i32,
+    y: i32,
+) -> (f64, f64, f64, f64) {
+    let tiles_per_side = 2_f64.powi(z);
+    let tile_width = (bounds.maxx - bounds.minx) / tiles_per_side;
+    let tile_height = (bounds.maxy - bounds.miny) / tiles_per_side;
+
+    let minx = bounds.minx + x as f64 * tile_width;
+    let maxx = bounds.minx + (x + 1) as f64 * tile_width;
+    let maxy = bounds.maxy - y as f64 * tile_height;
+    let miny = bounds.maxy - (y + 1) as f64 * tile_height;
+
+    (minx, miny, maxx, maxy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_epsg_code() {
+        let result = normalize_crs(Some("EPSG:4326"));
+        assert_eq!(result.crs, Some("EPSG:4326".to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_STANDARD);
+
+        let result = normalize_crs(Some("epsg:3857"));
+        assert_eq!(result.crs, Some("EPSG:3857".to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_STANDARD);
+    }
+
+    #[test]
+    fn test_normalize_wgs84_alias() {
+        let result = normalize_crs(Some("WGS84"));
+        assert_eq!(result.crs, Some("EPSG:4326".to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_STANDARD);
+
+        let result = normalize_crs(Some("CRS84"));
+        assert_eq!(result.crs, Some("EPSG:4326".to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_STANDARD);
+
+        let result = normalize_crs(Some("urn:ogc:def:crs:OGC:1.3:CRS84"));
+        assert_eq!(result.crs, Some("EPSG:4326".to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_STANDARD);
+    }
+
+    #[test]
+    fn test_normalize_none() {
+        let result = normalize_crs(None);
+        assert_eq!(result.crs, None);
+        assert_eq!(result.crs_type, CRS_TYPE_CUSTOM);
+    }
+
+    #[test]
+    fn test_normalize_custom_name() {
+        let result = normalize_crs(Some("LOCAL_GRID"));
+        assert_eq!(result.crs, Some("LOCAL_GRID".to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_CUSTOM);
+    }
+
+    #[test]
+    fn test_normalize_wkt_with_epsg() {
+        let wkt = r#"GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295],AUTHORITY["EPSG","4326"]]"#;
+        let result = normalize_crs(Some(wkt));
+        assert_eq!(result.crs, Some("EPSG:4326".to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_STANDARD);
+    }
+
+    #[test]
+    fn test_normalize_wkt_without_epsg() {
+        let wkt = r#"PROJCS["Local_Grid",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Transverse_Mercator"],UNIT["Meter",1]]"#;
+        let result = normalize_crs(Some(wkt));
+        assert_eq!(result.crs, Some(wkt.to_string()));
+        assert_eq!(result.crs_type, CRS_TYPE_CUSTOM);
+    }
+
+    #[test]
+    fn test_data_bounds_json() {
+        let bounds = DataBounds {
+            minx: 1000.0,
+            miny: 2000.0,
+            maxx: 1500.0,
+            maxy: 2500.0,
+        };
+        let json = bounds.to_json();
+        assert_eq!(json, r#"{"minx":1000,"miny":2000,"maxx":1500,"maxy":2500}"#);
+
+        let parsed = DataBounds::from_json(&json).unwrap();
+        assert_eq!(parsed.minx, 1000.0);
+        assert_eq!(parsed.maxy, 2500.0);
+    }
+
+    #[test]
+    fn test_calculate_custom_tile_bbox() {
+        let bounds = DataBounds {
+            minx: 1000.0,
+            miny: 2000.0,
+            maxx: 1500.0,
+            maxy: 2500.0,
+        };
+
+        let (minx, miny, maxx, maxy) = calculate_custom_tile_bbox(&bounds, 0, 0, 0);
+        assert!((minx - 1000.0).abs() < 1e-10);
+        assert!((miny - 2000.0).abs() < 1e-10);
+        assert!((maxx - 1500.0).abs() < 1e-10);
+        assert!((maxy - 2500.0).abs() < 1e-10);
+
+        let (minx, miny, maxx, maxy) = calculate_custom_tile_bbox(&bounds, 1, 0, 0);
+        assert!((minx - 1000.0).abs() < 1e-10);
+        assert!((maxx - 1250.0).abs() < 1e-10);
+        assert!((miny - 2250.0).abs() < 1e-10);
+        assert!((maxy - 2500.0).abs() < 1e-10);
+
+        let (minx, miny, maxx, maxy) = calculate_custom_tile_bbox(&bounds, 1, 1, 1);
+        assert!((minx - 1250.0).abs() < 1e-10);
+        assert!((maxx - 1500.0).abs() < 1e-10);
+        assert!((miny - 2000.0).abs() < 1e-10);
+        assert!((maxy - 2250.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_calculate_custom_tile_bbox_negative_coords() {
+        let bounds = DataBounds {
+            minx: -500.0,
+            miny: -300.0,
+            maxx: -400.0,
+            maxy: -200.0,
+        };
+
+        let (minx, miny, maxx, maxy) = calculate_custom_tile_bbox(&bounds, 0, 0, 0);
+        assert!((minx - (-500.0)).abs() < 1e-10);
+        assert!((miny - (-300.0)).abs() < 1e-10);
+        assert!((maxx - (-400.0)).abs() < 1e-10);
+        assert!((maxy - (-200.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_data_bounds_is_valid() {
+        let valid = DataBounds {
+            minx: 0.0,
+            miny: 0.0,
+            maxx: 100.0,
+            maxy: 100.0,
+        };
+        assert!(valid.is_valid());
+
+        let zero_extent = DataBounds {
+            minx: 0.0,
+            miny: 0.0,
+            maxx: 0.0,
+            maxy: 0.0,
+        };
+        assert!(!zero_extent.is_valid());
+
+        let negative_extent = DataBounds {
+            minx: 100.0,
+            miny: 100.0,
+            maxx: 0.0,
+            maxy: 0.0,
+        };
+        assert!(!negative_extent.is_valid());
+    }
+}

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -81,6 +81,11 @@ pub fn init_database(db_path: &Path) -> duckdb::Connection {
         "ALTER TABLE published_files ADD COLUMN tile_source VARCHAR DEFAULT 'duckdb'",
         [],
     );
+    let _ = conn.execute(
+        "ALTER TABLE files ADD COLUMN crs_type VARCHAR DEFAULT 'standard'",
+        [],
+    );
+    let _ = conn.execute("ALTER TABLE files ADD COLUMN data_bounds VARCHAR", []);
 
     conn.execute_batch(
         r"

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -8,15 +8,18 @@ use duckdb::types::ValueRef;
 use tracing::{info, warn};
 
 use crate::{
+    crs::{normalize_crs, DataBounds, CRS_TYPE_CUSTOM},
     http_errors::{bad_request, internal_error},
     mbtiles,
     models::{ErrorResponse, FeaturePropertiesResponse, FeatureProperty, FileItem, PreviewMeta},
-    tiles::build_mvt_select_sql,
+    tiles::{build_mvt_query_params, build_mvt_select_sql, TileParams},
     AppState,
 };
 
 pub type FileMetadata = (
     String,
+    Option<String>,
+    Option<String>,
     Option<String>,
     String,
     Option<String>,
@@ -26,13 +29,23 @@ pub type FileMetadata = (
     Option<i32>,
 );
 
+pub type TileFileMetadata = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    String,
+    Option<String>,
+    Option<String>,
+    String,
+);
+
 pub async fn list_files(
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
     let conn = state.db.lock().await;
     let mut stmt = conn
         .prepare(
-            "SELECT f.id, f.name, f.type, f.size, f.uploaded_at, f.status, f.crs, f.path, f.table_name, f.error, f.is_public, pf.slug
+            "SELECT f.id, f.name, f.type, f.size, f.uploaded_at, f.status, f.crs, f.crs_type, f.path, f.table_name, f.error, f.is_public, pf.slug
           FROM files f
           LEFT JOIN published_files pf ON f.id = pf.file_id
           ORDER BY f.uploaded_at DESC",
@@ -41,10 +54,12 @@ pub async fn list_files(
 
     let items_iter = stmt
         .query_map([], |row| {
-            let table_name: Option<String> = row.get(8)?;
-            let error: Option<String> = row.get(9)?;
-            let is_public: bool = row.get(10).unwrap_or(false);
-            let public_slug: Option<String> = row.get(11).ok();
+            let crs_type: Option<String> = row.get(7)?;
+            let path: String = row.get(8)?;
+            let table_name: Option<String> = row.get(9)?;
+            let error: Option<String> = row.get(10)?;
+            let is_public: bool = row.get(11).unwrap_or(false);
+            let public_slug: Option<String> = row.get(12).ok();
             Ok(FileItem {
                 id: row.get(0)?,
                 name: row.get(1)?,
@@ -56,7 +71,8 @@ pub async fn list_files(
                 },
                 status: row.get(5)?,
                 crs: row.get(6)?,
-                path: row.get(7)?,
+                crs_type,
+                path,
                 table_name,
                 error,
                 is_public: Some(is_public),
@@ -81,7 +97,7 @@ pub async fn get_preview_meta(
     let conn = state.db.lock().await;
 
     let mut stmt = conn
-        .prepare("SELECT name, crs, status, table_name, tile_format, tile_bounds, minzoom, maxzoom FROM files WHERE id = ?")
+        .prepare("SELECT name, crs, crs_type, data_bounds, status, table_name, tile_format, tile_bounds, minzoom, maxzoom FROM files WHERE id = ?")
         .map_err(internal_error)?;
 
     let meta: Option<FileMetadata> = stmt
@@ -95,11 +111,24 @@ pub async fn get_preview_meta(
                 row.get(5)?,
                 row.get(6)?,
                 row.get(7)?,
+                row.get(8)?,
+                row.get(9)?,
             ))
         })
         .ok();
 
-    let (name, crs, status, table_name, tile_format, tile_bounds, minzoom, maxzoom) = match meta {
+    let (
+        name,
+        crs,
+        crs_type,
+        data_bounds_json,
+        status,
+        table_name,
+        tile_format,
+        tile_bounds,
+        minzoom,
+        maxzoom,
+    ) = match meta {
         Some(m) => m,
         None => {
             return Err((
@@ -120,9 +149,17 @@ pub async fn get_preview_meta(
         ));
     }
 
+    let crs_type = crs_type.unwrap_or_else(|| "standard".to_string());
+    let data_bounds: Option<DataBounds> = data_bounds_json
+        .as_ref()
+        .and_then(|j| DataBounds::from_json(j));
+    let data_bounds_array = data_bounds.as_ref().map(|b| b.to_array());
+
     let bbox_values = if let Some(bounds_json) = tile_bounds {
         serde_json::from_str::<[f64; 4]>(&bounds_json).ok()
-    } else if let Some(tbl) = table_name {
+    } else if crs_type == CRS_TYPE_CUSTOM {
+        data_bounds_array
+    } else if let Some(tbl) = &table_name {
         let bbox_components_query = format!(
             "SELECT ST_XMin(b), ST_YMin(b), ST_XMax(b), ST_YMax(b) FROM (
                 SELECT ST_Extent(ST_Transform(geom, '{}', 'EPSG:4326', always_xy := true)) as b
@@ -146,14 +183,16 @@ pub async fn get_preview_meta(
         .ok()
         .filter(|b| b != &[0.0, 0.0, 0.0, 0.0])
     } else {
-        None
+        data_bounds_array
     };
 
     Ok(Json(PreviewMeta {
         id,
         name,
         crs,
+        crs_type,
         bbox: bbox_values,
+        data_bounds: data_bounds_array,
         tile_format,
         minzoom,
         maxzoom,
@@ -169,15 +208,9 @@ pub async fn get_tile(
     tracing::debug!(file_id = %id, z, x, y, "Tile request received");
     let conn = state.db.lock().await;
 
-    let (crs, status, table_name, tile_format, file_path): (
-        Option<String>,
-        String,
-        Option<String>,
-        Option<String>,
-        String,
-    ) = conn
+    let meta: TileFileMetadata = conn
         .query_row(
-            "SELECT crs, status, table_name, tile_format, path FROM files WHERE id = ?",
+            "SELECT crs, crs_type, data_bounds, status, table_name, tile_format, path FROM files WHERE id = ?",
             duckdb::params![id],
             |row| {
                 Ok((
@@ -186,6 +219,8 @@ pub async fn get_tile(
                     row.get(2)?,
                     row.get(3)?,
                     row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
                 ))
             },
         )
@@ -197,6 +232,8 @@ pub async fn get_tile(
                 }),
             )
         })?;
+
+    let (crs, crs_type, data_bounds_json, status, table_name, tile_format, file_path) = meta;
 
     if status != "ready" {
         return Err((
@@ -251,15 +288,29 @@ pub async fn get_tile(
         )
     })?;
 
-    let source_crs = crs.as_deref().unwrap_or("EPSG:4326");
+    let tile_params = TileParams {
+        source_crs: crs.clone().unwrap_or_else(|| "EPSG:4326".to_string()),
+        crs_type: crs_type.clone().unwrap_or_else(|| "standard".to_string()),
+        data_bounds: data_bounds_json
+            .as_ref()
+            .and_then(|j| DataBounds::from_json(j)),
+    };
 
     let select_sql =
-        build_mvt_select_sql(&conn, &id, &table_name, source_crs).map_err(internal_error)?;
+        build_mvt_select_sql(&conn, &id, &table_name, &tile_params, z, x, y).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Tile generation error: {}", e.0),
+                }),
+            )
+        })?;
+
+    let query_params = build_mvt_query_params(&tile_params, z, x, y);
+    let params_slice: Vec<&dyn duckdb::ToSql> = query_params.iter().map(|p| p.as_ref()).collect();
 
     let mvt_blob: Option<Vec<u8>> =
-        match conn.query_row(&select_sql, duckdb::params![z, x, y, z, x, y], |row| {
-            row.get(0)
-        }) {
+        match conn.query_row(&select_sql, params_slice.as_slice(), |row| row.get(0)) {
             Ok(blob) => Some(blob),
             Err(e) => {
                 tracing::error!(z, x, y, error = %e, sql = %select_sql, "Tile generation failed");
@@ -746,4 +797,86 @@ pub async fn get_public_url(
             }),
         )),
     }
+}
+
+pub async fn update_crs(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Json(req): Json<crate::models::UpdateCrsRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let conn = state.db.lock().await;
+
+    let (status, old_crs): (String, Option<String>) = conn
+        .query_row(
+            "SELECT status, crs FROM files WHERE id = ?",
+            duckdb::params![&id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .map_err(|_| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "File not found".to_string(),
+                }),
+            )
+        })?;
+
+    if status != "ready" {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: "File is not ready".to_string(),
+            }),
+        ));
+    }
+
+    // Only update if crs is provided and different from current
+    let new_crs = match req.crs {
+        Some(crs) if crs.trim().is_empty() => None,
+        Some(crs) => Some(crs.trim().to_string()),
+        None => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "crs field is required".to_string(),
+                }),
+            ));
+        }
+    };
+
+    // Skip update if value unchanged
+    if new_crs == old_crs {
+        let current_crs_type: Option<String> = conn
+            .query_row(
+                "SELECT crs_type FROM files WHERE id = ?",
+                duckdb::params![&id],
+                |row| row.get(0),
+            )
+            .ok()
+            .flatten();
+
+        drop(conn);
+
+        return Ok(Json(serde_json::json!({
+            "id": id,
+            "crs": old_crs,
+            "crsType": current_crs_type.unwrap_or_else(|| "standard".to_string())
+        })));
+    }
+
+    let normalized = normalize_crs(new_crs.as_deref());
+
+    conn.execute(
+        "UPDATE files SET crs = ?, crs_type = ? WHERE id = ?",
+        duckdb::params![normalized.crs, normalized.crs_type, &id],
+    )
+    .map_err(internal_error)?;
+
+    drop(conn);
+
+    Ok(Json(serde_json::json!({
+        "id": id,
+        "crs": normalized.crs,
+        "crsType": normalized.crs_type
+    })))
 }

--- a/backend/src/import.rs
+++ b/backend/src/import.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
+use crate::crs::{normalize_crs, DataBounds};
+
 pub async fn import_spatial_data(
     db: &Arc<Mutex<duckdb::Connection>>,
     source_id: &str,
@@ -36,13 +38,8 @@ pub async fn import_spatial_data(
 
     let detected_crs: Option<String> = conn.query_row(&crs_query, [], |row| row.get(0)).ok();
 
-    // Update files table with detected CRS
-    if let Some(crs) = &detected_crs {
-        let _ = conn.execute(
-            "UPDATE files SET crs = ? WHERE id = ?",
-            duckdb::params![crs, source_id],
-        );
-    }
+    // Normalize CRS and determine type
+    let normalized = normalize_crs(detected_crs.as_deref());
 
     // 2. Import Data into a per-dataset table (layer_<id>) so we can preserve columns.
     // We keep a stable feature id column (fid) for MVT feature ids.
@@ -60,11 +57,42 @@ pub async fn import_spatial_data(
     conn.execute(&create_sql, [])
         .map_err(|e| format!("Spatial import failed: {}", e))?;
 
-    // Record table name on the file record.
-    let _ = conn.execute(
-        "UPDATE files SET table_name = ? WHERE id = ?",
-        duckdb::params![safe_table_name.as_str(), source_id],
+    // Calculate data_bounds (extent of all geometries)
+    let bounds_query = format!(
+        "SELECT ST_XMin(e), ST_YMin(e), ST_XMax(e), ST_YMax(e) FROM (SELECT ST_Extent(geom) as e FROM \"{safe_table_name}\")"
     );
+    let data_bounds: Option<DataBounds> = conn
+        .query_row(&bounds_query, [], |row| {
+            let minx: Option<f64> = row.get(0).ok();
+            let miny: Option<f64> = row.get(1).ok();
+            let maxx: Option<f64> = row.get(2).ok();
+            let maxy: Option<f64> = row.get(3).ok();
+            match (minx, miny, maxx, maxy) {
+                (Some(x1), Some(y1), Some(x2), Some(y2)) => Ok(Some(DataBounds {
+                    minx: x1,
+                    miny: y1,
+                    maxx: x2,
+                    maxy: y2,
+                })),
+                _ => Ok(None),
+            }
+        })
+        .ok()
+        .flatten();
+
+    // Update files table with CRS info and data_bounds
+    let data_bounds_json = data_bounds.map(|b| b.to_json());
+    conn.execute(
+        "UPDATE files SET crs = ?, crs_type = ?, data_bounds = ?, table_name = ? WHERE id = ?",
+        duckdb::params![
+            normalized.crs,
+            normalized.crs_type,
+            data_bounds_json,
+            safe_table_name.as_str(),
+            source_id
+        ],
+    )
+    .map_err(|e| format!("Failed to update file metadata: {}", e))?;
 
     // 3. Normalize/rename columns when needed and capture metadata.
     // DuckDB is case-insensitive for identifiers, so we treat case-only differences as conflicts.

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod auth_routes;
 mod config;
+mod crs;
 mod db;
 mod handlers;
 mod http_errors;
@@ -68,6 +69,8 @@ mod tests {
             uploaded_at TIMESTAMP NOT NULL,
             status VARCHAR NOT NULL,
             crs VARCHAR,
+            crs_type VARCHAR DEFAULT 'standard',
+            data_bounds VARCHAR,
             path VARCHAR NOT NULL,
             table_name VARCHAR,
             error VARCHAR,
@@ -136,6 +139,7 @@ mod tests {
             uploaded_at: uploaded_at.to_string(),
             status: "uploaded".to_string(),
             crs: None,
+            crs_type: None,
             path: file_path.to_string_lossy().to_string(),
             table_name: None,
             error: None,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -27,6 +27,8 @@ pub struct FileItem {
     pub uploaded_at: String,
     pub status: String,
     pub crs: Option<String>,
+    #[serde(rename = "crsType", skip_serializing_if = "Option::is_none")]
+    pub crs_type: Option<String>,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub table_name: Option<String>,
@@ -50,13 +52,17 @@ pub struct PreviewMeta {
     pub id: String,
     pub name: String,
     pub crs: Option<String>,
-    pub bbox: Option<[f64; 4]>, // minx, miny, maxx, maxy in WGS84
+    #[serde(rename = "crsType")]
+    pub crs_type: String,
+    pub bbox: Option<[f64; 4]>,
+    #[serde(rename = "dataBounds", skip_serializing_if = "Option::is_none")]
+    pub data_bounds: Option<[f64; 4]>,
     #[serde(rename = "tileFormat", skip_serializing_if = "Option::is_none")]
-    pub tile_format: Option<String>, // "mvt", "png", or null
+    pub tile_format: Option<String>,
     #[serde(rename = "minZoom", skip_serializing_if = "Option::is_none")]
-    pub minzoom: Option<i32>, // MBTiles: valid zoom range (min), null for dynamic tables
+    pub minzoom: Option<i32>,
     #[serde(rename = "maxZoom", skip_serializing_if = "Option::is_none")]
-    pub maxzoom: Option<i32>, // MBTiles: valid zoom range (max), null for dynamic tables
+    pub maxzoom: Option<i32>,
 }
 
 #[allow(dead_code)]
@@ -120,4 +126,9 @@ pub struct PublicTileMeta {
     pub tile_url: String,
     #[serde(rename = "viewerUrl")]
     pub viewer_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateCrsRequest {
+    pub crs: Option<String>,
 }

--- a/backend/src/public.rs
+++ b/backend/src/public.rs
@@ -11,11 +11,12 @@ use tokio::{
 use tracing::error;
 
 use crate::{
-    handlers::validate_tile_coords,
+    crs::DataBounds,
+    handlers::{validate_tile_coords, TileFileMetadata},
     http_errors::internal_error,
     mbtiles,
     models::{ErrorResponse, PublicTileMeta},
-    tiles::build_mvt_select_sql,
+    tiles::{build_mvt_query_params, build_mvt_select_sql, TileParams},
     AppState,
 };
 
@@ -42,17 +43,11 @@ pub async fn get_public_tile(
             )
         })?;
 
-    let (crs, status, table_name, tile_format, file_path): (
-        Option<String>,
-        String,
-        Option<String>,
-        Option<String>,
-        String,
-    ) = conn
+    let meta: TileFileMetadata = conn
         .query_row(
-            "SELECT crs, status, table_name, tile_format, path FROM files WHERE id = ? AND is_public = TRUE",
+            "SELECT crs, crs_type, data_bounds, status, table_name, tile_format, path FROM files WHERE id = ? AND is_public = TRUE",
             duckdb::params![&file_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?)),
         )
         .map_err(|_| {
             (
@@ -62,6 +57,8 @@ pub async fn get_public_tile(
                 }),
             )
         })?;
+
+    let (crs, crs_type, data_bounds_json, status, table_name, tile_format, file_path) = meta;
 
     if status != "ready" {
         return Err((
@@ -109,15 +106,29 @@ pub async fn get_public_tile(
         )
     })?;
 
-    let source_crs = crs.as_deref().unwrap_or("EPSG:4326");
+    let tile_params = TileParams {
+        source_crs: crs.clone().unwrap_or_else(|| "EPSG:4326".to_string()),
+        crs_type: crs_type.clone().unwrap_or_else(|| "standard".to_string()),
+        data_bounds: data_bounds_json
+            .as_ref()
+            .and_then(|j| DataBounds::from_json(j)),
+    };
 
-    let select_sql =
-        build_mvt_select_sql(&conn, &file_id, &table_name, source_crs).map_err(internal_error)?;
+    let select_sql = build_mvt_select_sql(&conn, &file_id, &table_name, &tile_params, z, x, y)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Tile generation error: {}", e.0),
+                }),
+            )
+        })?;
+
+    let query_params = build_mvt_query_params(&tile_params, z, x, y);
+    let params_slice: Vec<&dyn duckdb::ToSql> = query_params.iter().map(|p| p.as_ref()).collect();
 
     let mvt_blob: Option<Vec<u8>> =
-        match conn.query_row(&select_sql, duckdb::params![z, x, y, z, x, y], |row| {
-            row.get(0)
-        }) {
+        match conn.query_row(&select_sql, params_slice.as_slice(), |row| row.get(0)) {
             Ok(blob) => Some(blob),
             Err(e) => {
                 error!(z, x, y, slug = %slug, error = %e, "Public tile generation failed");

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::DefaultBodyLimit,
-    routing::{get, post},
+    routing::{get, post, put},
     Router,
 };
 use axum_login::AuthManagerLayerBuilder;
@@ -14,7 +14,7 @@ use tower_sessions::SessionManagerLayer;
 use crate::{
     handlers::{
         check_is_initialized, get_feature_properties, get_file_schema, get_preview_meta,
-        get_public_url, health_check, list_files, publish_file, unpublish_file,
+        get_public_url, health_check, list_files, publish_file, unpublish_file, update_crs,
     },
     public::{get_public_pmtiles, get_public_tile, get_public_tile_meta, head_public_pmtiles},
     upload::upload_file,
@@ -36,6 +36,7 @@ fn build_api_router_with_auth(state: AppState, with_auth: bool) -> Router {
         .allow_methods([
             axum::http::Method::GET,
             axum::http::Method::POST,
+            axum::http::Method::PUT,
             axum::http::Method::DELETE,
         ])
         .allow_headers([
@@ -86,7 +87,8 @@ fn build_api_router_with_auth(state: AppState, with_auth: bool) -> Router {
         .route("/api/files/{id}/schema", get(get_file_schema))
         .route("/api/files/{id}/publish", post(publish_file))
         .route("/api/files/{id}/unpublish", post(unpublish_file))
-        .route("/api/files/{id}/public-url", get(get_public_url));
+        .route("/api/files/{id}/public-url", get(get_public_url))
+        .route("/api/files/{id}/crs", put(update_crs));
 
     if with_auth {
         api_router = api_router.route_layer(axum_login::login_required!(crate::AuthBackend));

--- a/backend/src/tiles.rs
+++ b/backend/src/tiles.rs
@@ -1,35 +1,88 @@
 use duckdb::Connection;
 
+use crate::crs::{calculate_custom_tile_bbox, DataBounds, CRS_TYPE_CUSTOM};
+
+pub struct TileParams {
+    pub source_crs: String,
+    pub crs_type: String,
+    pub data_bounds: Option<DataBounds>,
+}
+
+#[derive(Debug)]
+pub struct TileError(pub String);
+
+impl std::fmt::Display for TileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for TileError {}
+
+impl From<duckdb::Error> for TileError {
+    fn from(e: duckdb::Error) -> Self {
+        TileError(e.to_string())
+    }
+}
+
 pub fn build_mvt_select_sql(
     conn: &Connection,
     source_id: &str,
     table_name: &str,
-    source_crs: &str,
-) -> Result<String, duckdb::Error> {
-    // Build property struct keys based on captured column metadata.
-    // We keep property keys as original names for UX.
-    // Note: We exclude fid + geom.
-    let mut props_stmt = conn.prepare(
-        "SELECT normalized_name, original_name\n         FROM dataset_columns\n         WHERE source_id = ?\n         ORDER BY ordinal",
-    )?;
-    let props_iter = props_stmt.query_map(duckdb::params![source_id], |row| {
-        let normalized: String = row.get(0)?;
-        let original: String = row.get(1)?;
-        Ok((normalized, original))
-    })?;
+    params: &TileParams,
+    z: i32,
+    x: i32,
+    y: i32,
+) -> Result<String, TileError> {
+    if params.crs_type == CRS_TYPE_CUSTOM {
+        match &params.data_bounds {
+            None => {
+                return Err(TileError(
+                    "Custom CRS requires data_bounds for tile generation".to_string(),
+                ));
+            }
+            Some(bounds) if !bounds.is_valid() => {
+                return Err(TileError(
+                    "Custom CRS has invalid data_bounds (zero or negative extent)".to_string(),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let mut props_stmt = conn
+        .prepare(
+            "SELECT normalized_name, original_name\n         FROM dataset_columns\n         WHERE source_id = ?\n         ORDER BY ordinal",
+        )
+        .map_err(|e| TileError(format!("Failed to prepare column query: {}", e)))?;
+
+    let props_iter = props_stmt
+        .query_map(duckdb::params![source_id], |row| {
+            let normalized: String = row.get(0)?;
+            let original: String = row.get(1)?;
+            Ok((normalized, original))
+        })
+        .map_err(|e| TileError(format!("Failed to query columns: {}", e)))?;
 
     let mut struct_fields = Vec::new();
-    struct_fields.push(format!(
-        "geom := ST_AsMVTGeom(\n                    ST_Transform(geom, '{source_crs}', 'EPSG:3857', always_xy := true),\n                    ST_Extent(ST_TileEnvelope(?, ?, ?)),\n                    4096, 256, true\n                )"
-    ));
+
+    if params.crs_type == CRS_TYPE_CUSTOM {
+        let bounds = params.data_bounds.as_ref().unwrap();
+        let (minx, miny, maxx, maxy) = calculate_custom_tile_bbox(bounds, z, x, y);
+        struct_fields.push(format!(
+            "geom := ST_AsMVTGeom(\n                    geom,\n                    ST_MakeBox2D(ST_Point({minx}, {miny}), ST_Point({maxx}, {maxy})),\n                    4096, 256, true\n                )"
+        ));
+    } else {
+        let source_crs = &params.source_crs;
+        struct_fields.push(format!(
+            "geom := ST_AsMVTGeom(\n                    ST_Transform(geom, '{source_crs}', 'EPSG:3857', always_xy := true),\n                    ST_Extent(ST_TileEnvelope(?, ?, ?)),\n                    4096, 256, true\n                )"
+        ));
+    }
+
     struct_fields.push("fid := fid".to_string());
 
     for entry in props_iter {
         let (normalized, original) = entry?;
-
-        // Use the original column name as the MVT property key.
-        // DuckDB `struct_pack` uses identifier keys; quoted identifiers allow spaces/symbols.
-        // Escape embedded double quotes per SQL identifier rules.
         let key = original.replace('"', "\"\"");
         struct_fields.push(format!("\"{key}\" := \"{normalized}\""));
     }
@@ -39,7 +92,44 @@ pub fn build_mvt_select_sql(
         struct_fields.join(",\n                ")
     );
 
-    Ok(format!(
-        "SELECT ST_AsMVT(feature, 'layer', 4096, 'geom', 'fid') FROM (\n            SELECT {struct_expr} as feature\n            FROM \"{table_name}\"\n            WHERE ST_Intersects(\n                ST_Transform(geom, '{source_crs}', 'EPSG:3857', always_xy := true),\n                ST_TileEnvelope(?, ?, ?)\n            )\n        )"
-    ))
+    if params.crs_type == CRS_TYPE_CUSTOM {
+        Ok(format!(
+            "SELECT ST_AsMVT(feature, 'layer', 4096, 'geom', 'fid') FROM (\n                SELECT {struct_expr} as feature\n                FROM \"{table_name}\"\n                WHERE ST_Intersects(\n                    geom,\n                    ST_MakeEnvelope(?, ?, ?, ?)\n                )\n            )"
+        ))
+    } else {
+        let source_crs = &params.source_crs;
+        Ok(format!(
+            "SELECT ST_AsMVT(feature, 'layer', 4096, 'geom', 'fid') FROM (\n                SELECT {struct_expr} as feature\n                FROM \"{table_name}\"\n                WHERE ST_Intersects(\n                    ST_Transform(geom, '{source_crs}', 'EPSG:3857', always_xy := true),\n                    ST_TileEnvelope(?, ?, ?)\n                )\n            )"
+        ))
+    }
+}
+
+pub fn build_mvt_query_params(
+    params: &TileParams,
+    z: i32,
+    x: i32,
+    y: i32,
+) -> Vec<Box<dyn duckdb::ToSql>> {
+    if params.crs_type == CRS_TYPE_CUSTOM {
+        let bounds = params
+            .data_bounds
+            .as_ref()
+            .expect("data_bounds required for custom CRS");
+        let (minx, miny, maxx, maxy) = calculate_custom_tile_bbox(bounds, z, x, y);
+        vec![
+            Box::new(minx),
+            Box::new(miny),
+            Box::new(maxx),
+            Box::new(maxy),
+        ]
+    } else {
+        vec![
+            Box::new(z),
+            Box::new(x),
+            Box::new(y),
+            Box::new(z),
+            Box::new(x),
+            Box::new(y),
+        ]
+    }
 }

--- a/backend/src/upload.rs
+++ b/backend/src/upload.rs
@@ -224,6 +224,7 @@ pub async fn upload_file(
         uploaded_at,
         status: "uploaded".to_string(),
         crs: None,
+        crs_type: None,
         path: rel_string,
         table_name: None,
         error: None,

--- a/docs/dev/todo.md
+++ b/docs/dev/todo.md
@@ -23,7 +23,163 @@
 - **Issue**: docker_smoke in CI took ~15min with poor ROI (e2e already covers functionality)
 - **Solution**: Removed from CI, kept only in release/nightly workflows for Docker image validation
 
-## Future Enhancements
+## Custom CRS Support (Phase 1)
+
+**Goal**: 支持预览自定义坐标系数据（如本地测量坐标、建筑平面图）
+
+**Scope**: 单文件预览，不支持发布公开瓦片
+
+### User Story
+
+1. 用户上传本地坐标系数据（无 EPSG code）
+2. 系统自动识别为 custom CRS
+3. Preview 正常显示，坐标轴显示原始坐标
+4. 用户可手动修改 CRS 定义
+
+### CRS Classification Rules
+
+```
+ST_Read_Meta 结果 → 归一化 + 分类
+├── NULL（无 CRS 声明）→ crs=null, crs_type=custom
+├── EPSG:XXXX → crs="EPSG:XXXX", crs_type=standard
+├── WGS84 / CRS84 → crs="EPSG:4326", crs_type=standard
+├── WKT + AUTHORITY["EPSG","XXXX"] → crs="EPSG:XXXX", crs_type=standard
+├── WKT 无 EPSG AUTHORITY → crs=完整WKT, crs_type=custom
+└── 其他字符串 → crs=原值, crs_type=custom
+```
+
+### Tasks
+
+#### 1. Database
+- [x] files 表添加 `crs_type VARCHAR DEFAULT 'standard'`
+- [x] files 表添加 `data_bounds VARCHAR` (JSON: {minx, miny, maxx, maxy})
+
+#### 2. Backend
+
+**2.1 新建 crs.rs**
+- [x] `normalize_crs(raw: Option<&str>) -> NormalizedCrs`
+- [x] `parse_wkt(wkt: &str) -> NormalizedCrs` - 解析 WKT 中的 AUTHORITY
+- [x] `DataBounds` struct + `is_valid()` 方法
+- [x] `calculate_custom_tile_bbox(bounds, z, x, y) -> (minx, miny, maxx, maxy)`
+
+**2.2 models.rs**
+- [x] FileItem 新增 `crs_type: Option<String>`
+- [x] PreviewMeta 新增 `crs_type: String, data_bounds: Option<[f64; 4]>`
+- [x] UpdateCrsRequest struct
+
+**2.3 import.rs**
+- [x] 调用 `normalize_crs()` 归一化 CRS
+- [x] 更新 files.crs, files.crs_type
+- [x] 计算所有文件的 data_bounds: `ST_Extent(geom)`
+
+**2.4 tiles.rs**
+- [x] TileParams struct
+- [x] TileError struct + From<duckdb::Error>
+- [x] `build_mvt_select_sql`: custom 用 `calculate_custom_tile_bbox` + `ST_MakeEnvelope`
+- [x] `build_mvt_query_params`: 根据类型返回正确的参数
+
+**2.5 handlers.rs**
+- [x] `get_preview_meta`: 返回 crs_type, data_bounds
+- [x] `get_preview_meta`: bbox 计算 - custom 用 data_bounds，standard 用 ST_Transform
+- [x] `update_crs`: `PUT /api/files/:id/crs`
+  - 请求体 `{ crs: string }` (必填)
+  - 只更新元数据，不重算 data_bounds
+
+**2.6 routes.rs**
+- [x] 添加 PUT 方法到 CORS 配置
+- [x] 添加 `/api/files/{id}/crs` 路由
+
+**2.7 public.rs**
+- [x] 更新 `get_public_tile` 支持自定义 CRS
+
+#### 3. Frontend
+
+**3.1 Preview.jsx**
+- [x] 检测 `meta.crsType === 'custom'`
+- [x] `calculateCustomResolutions()` 函数 + 边界检查
+- [x] custom 时构建 TileGrid:
+  - extent = meta.dataBounds
+  - origin = [minx, maxy] (左上角)
+  - resolutions = 计算 z=0 到 z=20
+- [x] 创建 Projection: code, units='m', extent
+- [x] 显示 custom CRS 标签（橙色样式）
+
+#### 4. Test Data
+
+**4.1 GeoJSON (testdata/custom-crs/)**
+- [x] simple_custom_crs.geojson - 无 CRS → custom
+- [x] complex_custom_crs.geojson - 自定义名 → custom
+- [x] no_crs_test.geojson - 无 CRS → custom
+- [x] negative_coords_test.geojson - 负坐标测试
+- [x] README.md 更新
+
+#### 5. Tests
+- [x] Unit: crs.rs 各类输入 (9 tests)
+- [x] Unit: calculate_custom_tile_bbox (2 tests)
+- [x] Unit: DataBounds::is_valid (1 test)
+- [x] Backend: 40 tests passed
+- [ ] Integration: 自定义 CRS 上传流程
+- [ ] Integration: PUT /api/files/:id/crs
+- [ ] Integration: 自定义 CRS 瓦片请求
+- [ ] E2E: 预览页正常显示
+
+#### 6. Future Test Data (Optional)
+
+**6.1 Shapefile (testdata/custom-crs/shapefile/)**
+- [ ] custom_prj_no_auth.zip - .prj 无 EPSG AUTHORITY → custom
+- [ ] custom_prj_with_auth.zip - .prj 有 EPSG AUTHORITY → standard
+- [ ] no_prj_file.zip - 无 .prj 文件 → custom
+
+**6.2 GeoJSONSeq**
+- [ ] osm_lines_custom.geojsonl - 无 CRS → custom
+
+**6.3 TopoJSON**
+- [ ] osm_polygons_custom.topojson - 无 CRS → custom
+
+### Key Implementation Details
+
+**Custom Tile BBox Calculation:**
+```rust
+fn calculate_custom_tile_bbox(bounds: &DataBounds, z: i32, x: i32, y: i32) -> (f64, f64, f64, f64) {
+    let tiles_per_side = 2f64.powi(z);
+    let tile_width = (bounds.maxx - bounds.minx) / tiles_per_side;
+    let tile_height = (bounds.maxy - bounds.miny) / tiles_per_side;
+    
+    let minx = bounds.minx + x as f64 * tile_width;
+    let maxx = bounds.minx + (x + 1) as f64 * tile_width;
+    let maxy = bounds.maxy - y as f64 * tile_height;  // Y 轴从上往下
+    let miny = bounds.maxy - (y + 1) as f64 * tile_height;
+    
+    (minx, miny, maxx, maxy)
+}
+```
+
+**Frontend Resolutions:**
+```javascript
+function calculateResolutions(bounds, maxZoom = 20) {
+  const maxDim = Math.max(bounds.maxx - bounds.minx, bounds.maxy - bounds.miny);
+  return Array.from({ length: maxZoom + 1 }, (_, z) => maxDim / (256 * Math.pow(2, z)));
+}
+```
+
+---
+
+## Code Quality Improvements
+
+### CRS Validation in Tile Generation
+
+- **Issue**: `tiles.rs` 中的 `source_crs` 在 standard 模式下直接插入 SQL
+- **Current Protection**: `crs_type` 由 `normalize_crs` 控制，只有 EPSG 格式才会被标记为 standard
+- **Risk**: 低（需要绕过 API 直接修改数据库才能利用）
+- **Solution**: 在 `build_mvt_select_sql` 中添加 CRS 格式验证
+- **Priority**: Low
+
+### Debug Logging Cleanup
+
+- **Issue**: handlers.rs contains debug `println!` statements (lines 179-182, 287, 304-307)
+- **Impact**: Verbose output in production logs
+- **Solution**: Remove or replace with proper logging framework (tracing/log crate)
+- **Priority**: Low
 
 ### MBTiles Connection Pool
 

--- a/frontend/src/Preview.jsx
+++ b/frontend/src/Preview.jsx
@@ -17,8 +17,23 @@ import TileLayer from 'ol/layer/Tile';
 import TileSource from 'ol/source/Tile';
 import TileDebug from 'ol/source/TileDebug';
 import MVT from 'ol/format/MVT';
+import Projection from 'ol/proj/Projection';
+import TileGrid from 'ol/tilegrid/TileGrid';
 import { fromLonLat, transformExtent } from 'ol/proj';
 import { Fill, Stroke, Style, Circle as CircleStyle } from 'ol/style';
+
+function calculateCustomResolutions(dataBounds, maxZoom = 20) {
+  const width = dataBounds[2] - dataBounds[0];
+  const height = dataBounds[3] - dataBounds[1];
+  const maxDim = Math.max(width, height);
+
+  if (maxDim <= 0) {
+    console.warn('Invalid data bounds: zero or negative extent');
+    return Array.from({ length: maxZoom + 1 }, (_, z) => 1 / Math.pow(2, z));
+  }
+
+  return Array.from({ length: maxZoom + 1 }, (_, z) => maxDim / (256 * Math.pow(2, z)));
+}
 
 export default function Preview() {
   const { id } = useParams();
@@ -277,9 +292,12 @@ export default function Preview() {
     const map = mapRef.current;
     const view = map.getView();
 
+    // Determine if this is a custom CRS
+    const isCustomCRS = meta.crsType === 'custom' && meta.dataBounds;
+
     // Update zoom limits based on meta
     const minZoom = meta.minZoom ?? 0;
-    const maxZoom = meta.maxZoom ?? 22;
+    const maxZoom = isCustomCRS ? 20 : (meta.maxZoom ?? 22);
 
     if (view.getMinZoom() !== minZoom) {
       view.setMinZoom(minZoom);
@@ -300,11 +318,37 @@ export default function Preview() {
     const tileUrl = `${window.location.origin}/api/files/${id}/tiles/{z}/{x}/{y}`;
 
     let tileLayer;
+    let customProjection = null;
+    let customTileGrid = null;
+
+    if (isCustomCRS) {
+      // Custom CRS: create custom projection and tile grid
+      const [minx, miny, maxx, maxy] = meta.dataBounds;
+
+      customProjection = new Projection({
+        code: meta.crs || 'CUSTOM_CRS',
+        units: 'm',
+        extent: [minx, miny, maxx, maxy],
+      });
+
+      const resolutions = calculateCustomResolutions(meta.dataBounds, 20);
+
+      customTileGrid = new TileGrid({
+        extent: [minx, miny, maxx, maxy],
+        origin: [minx, maxy], // Top-left origin (TMS-style)
+        resolutions: resolutions,
+        tileSize: 256,
+      });
+    }
 
     if (tileFormat === 'png') {
       // Raster tiles (PNG)
       tileLayer = new TileLayer({
-        source: new TileSource({ url: tileUrl }),
+        source: new TileSource({
+          url: tileUrl,
+          projection: customProjection || 'EPSG:3857',
+          tileGrid: customTileGrid,
+        }),
       });
     } else {
       // Vector tiles (MVT) - default
@@ -312,6 +356,8 @@ export default function Preview() {
         source: new VectorTileSource({
           format: new MVT(),
           url: tileUrl,
+          projection: customProjection || 'EPSG:3857',
+          tileGrid: customTileGrid,
         }),
         style: styleFunction,
       });
@@ -324,13 +370,20 @@ export default function Preview() {
     // 2. Fit bounds
     if (meta.bbox && meta.bbox.length === 4) {
       const [minx, miny, maxx, maxy] = meta.bbox;
-      // Backend sends WGS84, map is default Web Mercator (EPSG:3857)
-      const extent = transformExtent([minx, miny, maxx, maxy], 'EPSG:4326', 'EPSG:3857');
+
+      let extent;
+      if (isCustomCRS) {
+        // Custom CRS: use bbox directly (no transform needed)
+        extent = [minx, miny, maxx, maxy];
+      } else {
+        // Standard CRS: transform from WGS84 to Web Mercator
+        extent = transformExtent([minx, miny, maxx, maxy], 'EPSG:4326', 'EPSG:3857');
+      }
 
       map.getView().fit(extent, {
         padding: [50, 50, 50, 50],
         duration: 1000,
-        maxZoom: maxZoom, // Use the max zoom from metadata
+        maxZoom: maxZoom,
       });
     }
   }, [meta, id, styleFunction, tileFormat]);
@@ -362,7 +415,13 @@ export default function Preview() {
         {meta && (
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             <h1 style={{ fontSize: '18px', margin: 0 }}>{meta.name}</h1>
-            {meta.crs && <span className="badge">{meta.crs}</span>}
+            {meta.crsType === 'custom' ? (
+              <span className="badge" style={{ backgroundColor: '#f0ad4e', color: '#fff' }}>
+                {meta.crs || 'Custom CRS'}
+              </span>
+            ) : meta.crs ? (
+              <span className="badge">{meta.crs}</span>
+            ) : null}
           </div>
         )}
 

--- a/testdata/custom-crs/README.md
+++ b/testdata/custom-crs/README.md
@@ -1,51 +1,76 @@
 # 自定义坐标系测试数据
 
-本目录包含用于测试自定义CRS（无EPSG code）功能的测试数据。
+本目录包含用于测试自定义 CRS（无 EPSG code）功能的测试数据。
 
-## 文件说明
+## 测试文件
 
-### simple_custom_crs.geojson
-简单测试文件，包含4个features：
-- 2个Polygon（Building A, Building B）
-- 1个LineString（Road Segment）
-- 1个Point（Landmark）
-
-坐标范围：[1000, 2000] 到 [1500, 2500]
-CRS: LOCAL_GRID（无EPSG code）
-
-### complex_custom_crs.geojson
-复杂测试文件，包含5个features：
-- 1个MultiPolygon（building）
-- 1个Polygon（park）
-- 1个MultiLineString（road）
-- 2个Point（utility）
-
-坐标范围：[4800, 2800] 到 [5800, 3900]
-CRS: LOCAL_GRID_PROJECT（无EPSG code）
+| 文件 | CRS 场景 | 坐标范围 | 几何类型 | 预期行为 |
+|------|----------|----------|----------|----------|
+| `simple_custom_crs.geojson` | 无 CRS 声明 | [1000, 2000] - [1500, 2500] | Point, LineString, Polygon | crs=null, crs_type=custom |
+| `complex_custom_crs.geojson` | 自定义 CRS 名称 | [4800, 2800] - [5800, 3900] | Point, MultiLineString, Polygon, MultiPolygon | crs="LOCAL_GRID_PROJECT", crs_type=custom |
+| `no_crs_test.geojson` | 无 CRS 声明 | [950, 2000] - [1400, 2400] | Point, LineString, Polygon | crs=null, crs_type=custom |
+| `negative_coords_test.geojson` | 无 CRS + 负坐标 | [-500, -300] - [-250, -150] | Point, Polygon | crs=null, crs_type=custom, 测试负坐标处理 |
 
 ## 预期行为
 
 上传这些文件后：
-1. crs_type 应该被标记为 'custom'
-2. crs_wkt 应该存储完整的WKT定义
-3. tiling_scheme 应该自动计算
-4. Preview API 返回的 bbox 应该是原坐标系
-5. 瓦片生成应该在原坐标系内进行（不转换到EPSG:3857）
+
+1. `crs_type` 应该被标记为 `'custom'`
+2. `data_bounds` 应该存储原始坐标范围（JSON 格式）
+3. Preview API 返回的 `bbox` 应该直接使用 `data_bounds`（不做坐标转换）
+4. 瓦片生成应该在原坐标系内进行（不转换到 EPSG:3857）
+5. 前端应该使用自定义 TileGrid 和 Projection
+
+## API 响应示例
+
+### Preview API 响应
+
+```json
+{
+  "id": "abc123",
+  "name": "no_crs_test",
+  "crs": null,
+  "crsType": "custom",
+  "bbox": [950.0, 2000.0, 1400.0, 2400.0],
+  "dataBounds": [950.0, 2000.0, 1400.0, 2400.0],
+  "tileFormat": null,
+  "minZoom": null,
+  "maxZoom": null
+}
+```
+
+### File List API 响应
+
+```json
+{
+  "id": "abc123",
+  "name": "no_crs_test",
+  "crs": null,
+  "crsType": "custom",
+  ...
+}
+```
 
 ## 使用示例
 
 ```bash
 # 上传测试文件
-curl -X POST -F "file=@simple_custom_crs.geojson" http://localhost:3000/api/uploads
+curl -X POST -F "file=@no_crs_test.geojson" http://localhost:3000/api/uploads
 
 # 等待处理完成，然后获取预览元数据
 curl http://localhost:3000/api/files/{id}/preview
 
-# 应该看到：
-# {
-#   "crs_type": "custom",
-#   "crs_wkt": "...",
-#   "tiling_scheme": { ... },
-#   "bbox": [1000.0, 2000.0, 1500.0, 2500.0]
-# }
+# 请求瓦片
+curl http://localhost:3000/api/files/{id}/tiles/0/0/0 --output tile.mvt
 ```
+
+## CRS 分类规则
+
+| 输入 CRS | 归一化结果 | crs_type |
+|----------|------------|----------|
+| NULL（无声明） | NULL | custom |
+| EPSG:XXXX | EPSG:XXXX | standard |
+| WGS84 / CRS84 | EPSG:4326 | standard |
+| WKT + AUTHORITY["EPSG"] | EPSG:XXXX | standard |
+| WKT 无 EPSG AUTHORITY | 完整 WKT | custom |
+| 其他字符串 | 原值 | custom |

--- a/testdata/custom-crs/negative_coords_test.geojson
+++ b/testdata/custom-crs/negative_coords_test.geojson
@@ -1,0 +1,55 @@
+{
+  "type": "FeatureCollection",
+  "name": "negative_coords_test",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 1,
+        "name": "Zone A"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-500.0, -300.0],
+            [-400.0, -300.0],
+            [-400.0, -200.0],
+            [-500.0, -200.0],
+            [-500.0, -300.0]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 2,
+        "name": "Zone B"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-350.0, -250.0],
+            [-250.0, -250.0],
+            [-250.0, -150.0],
+            [-350.0, -150.0],
+            [-350.0, -250.0]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 3,
+        "name": "Center Point"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-300.0, -200.0]
+      }
+    }
+  ]
+}

--- a/testdata/custom-crs/no_crs_test.geojson
+++ b/testdata/custom-crs/no_crs_test.geojson
@@ -1,0 +1,75 @@
+{
+  "type": "FeatureCollection",
+  "name": "no_crs_test",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 1,
+        "name": "Building A",
+        "type": "commercial"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [1000.0, 2000.0],
+            [1100.0, 2000.0],
+            [1100.0, 2100.0],
+            [1000.0, 2100.0],
+            [1000.0, 2000.0]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 2,
+        "name": "Building B",
+        "type": "residential"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [1200.0, 2200.0],
+            [1350.0, 2200.0],
+            [1350.0, 2350.0],
+            [1200.0, 2350.0],
+            [1200.0, 2200.0]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 3,
+        "name": "Road Segment",
+        "type": "road"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [950.0, 2150.0],
+          [1050.0, 2250.0],
+          [1150.0, 2300.0],
+          [1300.0, 2400.0]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 4,
+        "name": "Landmark",
+        "type": "point_of_interest"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [1400.0, 2050.0]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add crs.rs module for CRS normalization and classification
- Auto-detect CRS type (standard/custom) on file import
- Calculate data_bounds for all spatial files
- Generate tiles in original coordinate space for custom CRS
- Add PUT /api/files/:id/crs API for CRS metadata updates
- Add frontend support for custom TileGrid and Projection
- Add test data files for custom CRS scenarios

## CRS Classification Rules

```
ST_Read_Meta result → normalization + classification
├── NULL/no declaration → crs=null, crs_type=custom
├── EPSG:XXXX → crs="EPSG:XXXX", crs_type=standard
├── WGS84/CRS84 aliases → crs="EPSG:4326", crs_type=standard
├── WKT with EPSG AUTHORITY → crs="EPSG:XXXX", crs_type=standard
├── WKT without EPSG AUTHORITY → crs=full WKT, crs_type=custom
└── Other strings → crs=original value, crs_type=custom
```

## Test Plan

- [x] 40 backend unit tests passed
- [x] 63 API tests passed  
- [x] 26 frontend unit tests passed
- [x] 21 E2E tests passed
- [x] Custom CRS test data files added

## Files Changed

- backend/src/crs.rs (new)
- backend/src/db.rs
- backend/src/handlers.rs
- backend/src/import.rs
- backend/src/lib.rs
- backend/src/models.rs
- backend/src/public.rs
- backend/src/routes.rs
- backend/src/tiles.rs
- backend/src/upload.rs
- frontend/src/Preview.jsx
- testdata/custom-crs/no_crs_test.geojson (new)
- testdata/custom-crs/negative_coords_test.geojson (new)
- docs/dev/todo.md
- testdata/custom-crs/README.md