### PR TITLE
feat(crs): detect custom CRS by validating coordinate bounds

### DIFF
--- a/backend/src/crs.rs
+++ b/backend/src/crs.rs
@@ -115,6 +115,10 @@ impl DataBounds {
     pub fn is_valid(&self) -> bool {
         self.maxx > self.minx && self.maxy > self.miny
     }
+
+    pub fn is_valid_wgs84(&self) -> bool {
+        self.minx >= -180.0 && self.maxx <= 180.0 && self.miny >= -90.0 && self.maxy <= 90.0
+    }
 }
 
 pub fn calculate_custom_tile_bbox(
@@ -280,5 +284,48 @@ mod tests {
             maxy: 0.0,
         };
         assert!(!negative_extent.is_valid());
+    }
+
+    #[test]
+    fn test_is_valid_wgs84() {
+        let wgs84_bounds = DataBounds {
+            minx: -74.1,
+            miny: 40.5,
+            maxx: -73.9,
+            maxy: 40.9,
+        };
+        assert!(wgs84_bounds.is_valid_wgs84());
+
+        let global_bounds = DataBounds {
+            minx: -180.0,
+            miny: -90.0,
+            maxx: 180.0,
+            maxy: 90.0,
+        };
+        assert!(global_bounds.is_valid_wgs84());
+
+        let out_of_range_x = DataBounds {
+            minx: 1000.0,
+            miny: 0.0,
+            maxx: 1500.0,
+            maxy: 100.0,
+        };
+        assert!(!out_of_range_x.is_valid_wgs84());
+
+        let out_of_range_y = DataBounds {
+            minx: 0.0,
+            miny: -300.0,
+            maxx: 100.0,
+            maxy: -200.0,
+        };
+        assert!(!out_of_range_y.is_valid_wgs84());
+
+        let negative_coords = DataBounds {
+            minx: -500.0,
+            miny: -300.0,
+            maxx: -400.0,
+            maxy: -200.0,
+        };
+        assert!(!negative_coords.is_valid_wgs84());
     }
 }

--- a/backend/src/import.rs
+++ b/backend/src/import.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::crs::{normalize_crs, DataBounds};
+use crate::crs::{normalize_crs, DataBounds, CRS_TYPE_CUSTOM};
 
 pub async fn import_spatial_data(
     db: &Arc<Mutex<duckdb::Connection>>,
@@ -79,6 +79,20 @@ pub async fn import_spatial_data(
         })
         .ok()
         .flatten();
+
+    // If GDAL reports EPSG:4326 but coordinates are outside valid WGS84 range,
+    // override to custom CRS (GDAL defaults to EPSG:4326 for GeoJSON without CRS)
+    let normalized = if normalized.crs.as_deref() == Some("EPSG:4326") {
+        match &data_bounds {
+            Some(bounds) if !bounds.is_valid_wgs84() => crate::crs::NormalizedCrs {
+                crs: None,
+                crs_type: CRS_TYPE_CUSTOM.to_string(),
+            },
+            _ => normalized,
+        }
+    } else {
+        normalized
+    };
 
     // Update files table with CRS info and data_bounds
     let data_bounds_json = data_bounds.map(|b| b.to_json());

--- a/frontend/src/Preview.jsx
+++ b/frontend/src/Preview.jsx
@@ -367,7 +367,24 @@ export default function Preview() {
     // Insert vector layer at index 0, tile grid stays on top
     map.getLayers().insertAt(0, tileLayer);
 
-    // 2. Fit bounds
+    // 2. Update View projection for custom CRS
+    if (isCustomCRS && customProjection) {
+      const [minx, miny, maxx, maxy] = meta.dataBounds;
+      const centerX = (minx + maxx) / 2;
+      const centerY = (miny + maxy) / 2;
+
+      map.setView(
+        new View({
+          projection: customProjection,
+          center: [centerX, centerY],
+          zoom: 0,
+          minZoom: minZoom,
+          maxZoom: maxZoom,
+        }),
+      );
+    }
+
+    // 3. Fit bounds
     if (meta.bbox && meta.bbox.length === 4) {
       const [minx, miny, maxx, maxy] = meta.bbox;
 

--- a/frontend/tests/custom-crs.spec.js
+++ b/frontend/tests/custom-crs.spec.js
@@ -1,0 +1,192 @@
+import { test, expect } from './fixtures';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loginUser, setupTestUser } from './auth-helper.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const customCrsDir = path.join(__dirname, '..', '..', 'testdata', 'custom-crs');
+
+test.describe('Custom CRS', () => {
+  test.beforeEach(async ({ workerServer, request }) => {
+    await workerServer.reset();
+    await setupTestUser(request);
+    await loginUser(request);
+  });
+
+  test('upload custom CRS file and verify API behavior', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    const customCrsFile = path.join(customCrsDir, 'no_crs_test.geojson');
+
+    await page.goto('/');
+
+    const input = page.getByTestId('file-input');
+    await input.setInputFiles(customCrsFile);
+
+    await expect(
+      page.locator('.row', { hasText: 'no_crs_test' }).getByText(/已就绪|等待处理/),
+    ).toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get('/api/files');
+          if (!response.ok()) return null;
+          const files = await response.json();
+          const file = files.find((f) => f.name === 'no_crs_test');
+          return file?.status;
+        },
+        { message: 'wait for file to be ready', timeout: 60000 },
+      )
+      .toBe('ready');
+
+    const filesResponse = await request.get('/api/files');
+    const files = await filesResponse.json();
+    const customCrsData = files.find((f) => f.name === 'no_crs_test');
+    expect(customCrsData).toBeDefined();
+    expect(customCrsData.crsType).toBe('custom');
+    expect(customCrsData.crs).toBeNull();
+
+    const fileId = customCrsData.id;
+
+    const previewResponse = await request.get(`/api/files/${fileId}/preview`);
+    expect(previewResponse.ok()).toBeTruthy();
+    const previewData = await previewResponse.json();
+
+    expect(previewData.crsType).toBe('custom');
+    expect(previewData.bbox).toBeDefined();
+    expect(previewData.bbox).toHaveLength(4);
+    expect(previewData.bbox[0]).toBeLessThan(previewData.bbox[2]);
+    expect(previewData.bbox[1]).toBeLessThan(previewData.bbox[3]);
+
+    const tileResponse = await request.get(`/api/files/${fileId}/tiles/0/0/0`);
+    expect(tileResponse.status()).toBe(200);
+    expect(tileResponse.headers()['content-type']).toContain('application/vnd.mapbox-vector-tile');
+  });
+
+  test('custom CRS with negative coordinates', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    const negativeCoordsFile = path.join(customCrsDir, 'negative_coords_test.geojson');
+
+    await page.goto('/');
+
+    const input = page.getByTestId('file-input');
+    await input.setInputFiles(negativeCoordsFile);
+
+    await expect(
+      page.locator('.row', { hasText: 'negative_coords_test' }).getByText(/已就绪|等待处理/),
+    ).toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get('/api/files');
+          if (!response.ok()) return null;
+          const files = await response.json();
+          const file = files.find((f) => f.name === 'negative_coords_test');
+          return file?.status;
+        },
+        { message: 'wait for file to be ready', timeout: 60000 },
+      )
+      .toBe('ready');
+
+    const filesResponse = await request.get('/api/files');
+    const files = await filesResponse.json();
+    const negativeData = files.find((f) => f.name === 'negative_coords_test');
+    expect(negativeData).toBeDefined();
+    expect(negativeData.crsType).toBe('custom');
+
+    const previewResponse = await request.get(`/api/files/${negativeData.id}/preview`);
+    expect(previewResponse.ok()).toBeTruthy();
+    const previewData = await previewResponse.json();
+
+    expect(previewData.bbox[0]).toBeLessThan(0);
+    expect(previewData.bbox[1]).toBeLessThan(0);
+  });
+
+  test('custom CRS with named CRS definition', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    const complexFile = path.join(customCrsDir, 'complex_custom_crs.geojson');
+
+    await page.goto('/');
+
+    const input = page.getByTestId('file-input');
+    await input.setInputFiles(complexFile);
+
+    await expect(
+      page.locator('.row', { hasText: 'complex_custom_crs' }).getByText(/已就绪|等待处理/),
+    ).toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get('/api/files');
+          if (!response.ok()) return null;
+          const files = await response.json();
+          const file = files.find((f) => f.name === 'complex_custom_crs');
+          return file?.status;
+        },
+        { message: 'wait for file to be ready', timeout: 60000 },
+      )
+      .toBe('ready');
+
+    const filesResponse = await request.get('/api/files');
+    const files = await filesResponse.json();
+    const complexData = files.find((f) => f.name === 'complex_custom_crs');
+    expect(complexData).toBeDefined();
+    expect(complexData.crsType).toBe('custom');
+    expect(complexData.crs).toBeNull();
+  });
+
+  test('custom CRS preview page loads tiles', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    const customCrsFile = path.join(customCrsDir, 'simple_custom_crs.geojson');
+
+    await page.goto('/');
+
+    const input = page.getByTestId('file-input');
+    await input.setInputFiles(customCrsFile);
+
+    await expect(
+      page.locator('.row', { hasText: 'simple_custom_crs' }).getByText(/已就绪|等待处理/),
+    ).toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get('/api/files');
+          if (!response.ok()) return null;
+          const files = await response.json();
+          const file = files.find((f) => f.name === 'simple_custom_crs');
+          return file?.status;
+        },
+        { message: 'wait for file to be ready', timeout: 60000 },
+      )
+      .toBe('ready');
+
+    const row = page.locator('.row', { hasText: 'simple_custom_crs' });
+    await row.click();
+
+    const sidebar = page.getByTestId('detail-sidebar');
+    await expect(sidebar.getByText('simple_custom_crs')).toBeVisible();
+
+    const previewLink = sidebar.getByTestId('open-preview');
+    await expect(previewLink).toBeVisible();
+
+    const [newPage] = await Promise.all([page.context().waitForEvent('page'), previewLink.click()]);
+
+    await newPage.waitForLoadState('networkidle');
+
+    expect(newPage.url()).toContain('/preview/');
+    await expect(newPage.getByText('simple_custom_crs')).toBeVisible();
+
+    const filesResponse = await request.get('/api/files');
+    const files = await filesResponse.json();
+    const simpleData = files.find((f) => f.name === 'simple_custom_crs');
+    const tileResponse = await request.get(`/api/files/${simpleData.id}/tiles/0/0/0`);
+    expect([200, 204]).toContain(tileResponse.status());
+  });
+});


### PR DESCRIPTION
## Summary

- GDAL 对没有 CRS 声明的 GeoJSON 默认返回 EPSG:4326，即使坐标明显不是 WGS84
- 添加坐标范围验证：当 GDAL 报告 EPSG:4326 但坐标超出 WGS84 范围时，自动分类为 custom CRS
- 修复前端 Preview 组件在 custom CRS 时未更新 View projection 的问题

## Changes

| File | Change |
|------|--------|
| `backend/src/crs.rs` | Add `is_valid_wgs84()` method to DataBounds |
| `backend/src/import.rs` | Validate coordinates after CRS detection |
| `frontend/src/Preview.jsx` | Update View projection for custom CRS |
| `frontend/tests/custom-crs.spec.js` | Add 4 E2E tests for custom CRS |

## Test Plan

- ✅ Backend: 67 tests passed
- ✅ Frontend: 26 unit tests + 25 E2E tests passed