### PR TITLE
fix: add WAL recovery and graceful shutdown for DuckDB

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -18,6 +18,34 @@ const DEV_SPATIAL_EXTENSION_RELATIVE_PATH: &str = "backend/extensions/spatial.du
 
 static SPATIAL_INSTALL_LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
 
+fn open_with_wal_recovery(db_path: &Path) -> duckdb::Connection {
+    match duckdb::Connection::open(db_path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            let err_str = e.to_string();
+            if err_str.contains("replaying WAL") || err_str.contains("WAL file") {
+                let wal_path = db_path.with_extension("duckdb.wal");
+                tracing::warn!(
+                    wal_path = %wal_path.display(),
+                    error = %err_str,
+                    "Corrupt WAL detected, removing and retrying"
+                );
+                if let Err(remove_err) = std::fs::remove_file(&wal_path) {
+                    tracing::error!(
+                        wal_path = %wal_path.display(),
+                        error = %remove_err,
+                        "Failed to remove corrupt WAL file"
+                    );
+                }
+                duckdb::Connection::open(db_path)
+                    .expect("Failed to open database after WAL cleanup")
+            } else {
+                panic!("Failed to open database: {}", e);
+            }
+        }
+    }
+}
+
 pub async fn reconcile_processing_files(
     db: &Arc<Mutex<duckdb::Connection>>,
 ) -> Result<usize, duckdb::Error> {
@@ -33,7 +61,7 @@ pub fn init_database(db_path: &Path) -> duckdb::Connection {
         std::fs::create_dir_all(parent).expect("Failed to create database directory");
     }
 
-    let conn = duckdb::Connection::open(db_path).expect("Failed to open database");
+    let conn = open_with_wal_recovery(db_path);
 
     ensure_spatial_extension(&conn).expect("Failed to install and load spatial extension");
 
@@ -366,5 +394,27 @@ mod tests {
         let path = Path::new("/tmp/mapflow's/spatial.duckdb_extension");
         let sql = build_load_extension_sql(path).expect("sql");
         assert_eq!(sql, "LOAD '/tmp/mapflow''s/spatial.duckdb_extension';");
+    }
+
+    #[test]
+    fn open_with_wal_recovery_removes_corrupt_wal_and_succeeds() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("test.duckdb");
+
+        let conn = duckdb::Connection::open(&db_path).expect("open");
+        conn.execute("CREATE TABLE test (id INTEGER)", [])
+            .expect("create table");
+        conn.execute("INSERT INTO test VALUES (1)", [])
+            .expect("insert");
+        drop(conn);
+
+        let wal_path = db_path.with_extension("duckdb.wal");
+        std::fs::write(&wal_path, b"corrupted wal data").expect("write corrupt wal");
+
+        let conn = open_with_wal_recovery(&db_path);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM test", [], |r| r.get(0))
+            .expect("query");
+        assert_eq!(count, 1);
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -70,5 +70,44 @@ async fn main() {
         .await
         .expect("failed to bind");
 
-    axum::serve(listener, app).await.expect("server failed");
+    let db_for_shutdown = db.clone();
+    let shutdown = async move {
+        shutdown_signal().await;
+        tracing::info!("Shutdown signal received, checkpointing database...");
+        let conn = db_for_shutdown.lock().await;
+        if let Err(e) = conn.execute("CHECKPOINT", []) {
+            tracing::error!(error = %e, "Failed to checkpoint database during shutdown");
+        } else {
+            tracing::info!("Database checkpoint completed");
+        }
+    };
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+        .expect("server failed");
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("Failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -17,6 +17,11 @@ React → HTTP → Axum → DuckDB
 - 本地加载失败时回退到 DuckDB 默认 `LOAD/INSTALL spatial` 流程
 - `backend/extensions/spatial-extension-manifest.json` 与 `Cargo.lock` 版本必须同步（CI 强校验）
 
+## 系统韧性
+
+- **启动恢复**：WAL 损坏时自动删除并重试（`db::open_with_wal_recovery`）
+- **优雅关闭**：SIGINT/SIGTERM 时执行 CHECKPOINT 刷入数据
+
 ## 认证
 
 Session Cookie → axum-login → tower-sessions → DuckDB


### PR DESCRIPTION
## Summary

- Add graceful shutdown with CHECKPOINT on SIGINT/SIGTERM to prevent WAL corruption
- Add WAL corruption recovery on startup (auto-removes corrupt WAL and retries)
- Add unit test for WAL recovery logic
- Document system resilience mechanisms in internal.md

## Problem

When the dev server is terminated with Ctrl+C, DuckDB's WAL file may not be properly flushed to the database. On next startup, this causes a panic:
```
INTERNAL Error: Failure while replaying WAL file
```

## Solution

1. **Graceful shutdown**: Catch SIGINT/SIGTERM signals and execute `CHECKPOINT` before exiting
2. **Startup recovery**: Detect corrupt WAL during database open and automatically remove it

## Test plan

- [x] Unit test for `open_with_wal_recovery`
- [x] All existing tests pass (43 unit + 82 integration + 25 E2E)
- [x] Manual test: `just start` → Ctrl+C → `just start` works without error