### PR TITLE
chore(hooks): remove MAPFLOW_SKIP_HOOK_TESTS bypass

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,8 +3,6 @@ set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-SKIP_TESTS="${MAPFLOW_SKIP_HOOK_TESTS:-}"
-
 echo "[pre-commit] spatial extension version sync check"
 bash "$ROOT_DIR/scripts/ci/check_spatial_extension_version.sh"
 
@@ -17,11 +15,6 @@ cargo clippy --manifest-path "$ROOT_DIR/backend/Cargo.toml" --all-targets -- -D 
 if [ -f "$ROOT_DIR/frontend/package.json" ]; then
   echo "[pre-commit] frontend biome format (check)"
   npm --prefix "$ROOT_DIR/frontend" run -s format:check
-fi
-
-if [ "$SKIP_TESTS" = "1" ]; then
-  echo "[pre-commit] skipping tests (MAPFLOW_SKIP_HOOK_TESTS=1)"
-  exit 0
 fi
 
 echo "[pre-commit] backend tests (cargo test)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,11 +3,6 @@ set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-if [ "${MAPFLOW_SKIP_HOOK_TESTS:-}" = "1" ]; then
-  echo "[pre-push] skipping tests (MAPFLOW_SKIP_HOOK_TESTS=1)"
-  exit 0
-fi
-
 echo "[pre-push] running full test suite"
 
 echo "[pre-push] spatial extension version sync check"


### PR DESCRIPTION
## Summary

- Remove `MAPFLOW_SKIP_HOOK_TESTS` environment variable that allowed bypassing tests in pre-commit and pre-push hooks
- This aligns with AGENTS.md policy: "禁止跳过 hooks：绝不使用 `git commit/push --no-verify`"

## Motivation

The bypass was a "hidden escape hatch" without documented use cases, contradicting the project's commitment to code quality gates.