### PR TITLE
fix: add sync_all() to prevent GDAL file race condition

### DIFF
--- a/backend/src/upload.rs
+++ b/backend/src/upload.rs
@@ -88,6 +88,8 @@ pub async fn upload_file(
         file.write_all(&chunk).await.map_err(internal_error)?;
     }
     file.flush().await.map_err(internal_error)?;
+    // Force sync to disk before background import to prevent GDAL race condition
+    file.get_ref().sync_all().await.map_err(internal_error)?;
     drop(file);
 
     let base_name = Path::new(&safe_name)


### PR DESCRIPTION
## Summary
- Fixes #94 - Flaky test `test_dynamic_table_preview_returns_null_zoom` was intermittently failing
- Added `sync_all()` call after file flush to ensure data is persisted to disk before background import task starts
- The race condition occurred when GDAL's `ST_Read` attempted to read files before the OS fully synced them

## Technical Details
The issue was in `upload.rs` where files are written with `BufWriter`. After `flush()` and `drop(file)`, the operating system may still have the file data in its page cache, not yet written to disk. When the background `tokio::spawn` task immediately calls `import_spatial_data()`, GDAL might try to read the file before it's fully available.

The fix adds `file.get_ref().sync_all().await?` which calls `fsync()` to ensure data is persisted before starting the import.

## Test plan
- [x] Ran the flaky test 5 times consecutively - all passed
- [x] All 82 API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)