### PR TITLE
feat(ci): add Windows platform support for releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -139,6 +139,10 @@ jobs:
             rust_target: aarch64-apple-darwin
             artifact_id: darwin-arm64
             duckdb_platform: osx_arm64
+          - os: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+            artifact_id: windows-amd64
+            duckdb_platform: windows_amd64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -173,6 +177,10 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      - name: Install protobuf compiler (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protobuf -y
+
       - name: Build backend binary
         run: cargo build --release --locked --manifest-path backend/Cargo.toml --target ${{ matrix.rust_target }}
 
@@ -188,7 +196,7 @@ jobs:
           bash scripts/release/package_bundle.sh \
             "${{ needs.meta.outputs.release_version }}" \
             "${{ matrix.artifact_id }}" \
-            "target/${{ matrix.rust_target }}/release/backend" \
+            "target/${{ matrix.rust_target }}/release/backend${{ matrix.os == 'windows-latest' && '.exe' || '' }}" \
             "${spatial_ext_path}" \
             "release-assets"
 
@@ -196,7 +204,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: binary-${{ matrix.artifact_id }}
-          path: release-assets/*.tar.gz
+          path: |
+            release-assets/*.tar.gz
+            release-assets/*.zip
 
   docker_build:
     needs:
@@ -359,3 +369,4 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             release-assets/**/*.tar.gz
+            release-assets/**/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,10 @@ jobs:
             rust_target: aarch64-apple-darwin
             artifact_id: darwin-arm64
             duckdb_platform: osx_arm64
+          - os: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+            artifact_id: windows-amd64
+            duckdb_platform: windows_amd64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -147,6 +151,10 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      - name: Install protobuf compiler (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protobuf -y
+
       - name: Build backend binary
         run: cargo build --release --locked --manifest-path backend/Cargo.toml --target ${{ matrix.rust_target }}
 
@@ -163,7 +171,7 @@ jobs:
           bash scripts/release/package_bundle.sh \
             "${{ github.ref_name }}" \
             "${{ matrix.artifact_id }}" \
-            "target/${{ matrix.rust_target }}/release/backend" \
+            "target/${{ matrix.rust_target }}/release/backend${{ matrix.os == 'windows-latest' && '.exe' || '' }}" \
             "${spatial_ext_path}" \
             "release-assets"
 
@@ -171,7 +179,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: binary-${{ matrix.artifact_id }}
-          path: release-assets/*.tar.gz
+          path: |
+            release-assets/*.tar.gz
+            release-assets/*.zip
 
   docker_build:
     needs: docker_smoke
@@ -317,3 +327,4 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             release-assets/**/*.tar.gz
+            release-assets/**/*.zip

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ License: Apache-2.0
 
 | Channel | Trigger | GitHub Release | GHCR Tags | Assets |
 |---|---|---|---|---|
-| Stable | `v*` tag push | Full release | `latest`, `vX.Y.Z` | Linux + macOS bundles |
-| Nightly | Daily schedule (`02:00 UTC`) + manual dispatch | Pre-release | `nightly`, `nightly-YYYYMMDD`, `nightly-<sha>` | Linux + macOS bundles |
+| Stable | `v*` tag push | Full release | `latest`, `vX.Y.Z` | Linux + macOS + Windows bundles |
+| Nightly | Daily schedule (`02:00 UTC`) + manual dispatch | Pre-release | `nightly`, `nightly-YYYYMMDD`, `nightly-<sha>` | Linux + macOS + Windows bundles |
 
 Each binary bundle contains:
 - `mapflow` backend executable
@@ -48,11 +48,21 @@ docker compose -f docker-compose.ghcr.yml down
 
 ## Quickstart (Binary Bundle)
 
-1. Download an asset from [GitHub Releases](https://github.com/sharkAndshark/mapflow/releases).
+1. Download an asset from [GitHub Releases](https://github.com/sharkAndshark/mapflow/releases):
+   - Linux: `mapflow-*-linux-amd64.tar.gz`
+   - macOS (Apple Silicon): `mapflow-*-darwin-arm64.tar.gz`
+   - Windows: `mapflow-*-windows-amd64.zip`
 2. Extract it, then run:
 
 ```bash
+# Linux/macOS
 ./mapflow
+
+# Windows (Command Prompt)
+mapflow.exe
+
+# Windows (PowerShell)
+.\mapflow.exe
 ```
 
 Binary bundles include `extensions/spatial.duckdb_extension` and load it automatically by default.
@@ -60,11 +70,21 @@ Binary bundles include `extensions/spatial.duckdb_extension` and load it automat
 Optional runtime config:
 
 ```bash
+# Linux/macOS
 export WEB_DIST=./dist
 export DB_PATH=./data/mapflow.duckdb
 export UPLOAD_DIR=./uploads
 export PORT=3000
 ./mapflow
+```
+
+```cmd
+:: Windows (Command Prompt)
+set WEB_DIST=.\dist
+set DB_PATH=.\data\mapflow.duckdb
+set UPLOAD_DIR=.\uploads
+set PORT=3000
+mapflow.exe
 ```
 
 ## Supported Upload Formats

--- a/backend/extensions/spatial-extension-manifest.json
+++ b/backend/extensions/spatial-extension-manifest.json
@@ -21,6 +21,11 @@
       "platform": "osx_arm64",
       "archive_url": "http://extensions.duckdb.org/v1.4.4/osx_arm64/spatial.duckdb_extension.gz",
       "local_relpath": "backend/extensions/duckdb/v1.4.4/osx_arm64/spatial.duckdb_extension"
+    },
+    {
+      "platform": "windows_amd64",
+      "archive_url": "http://extensions.duckdb.org/v1.4.4/windows_amd64/spatial.duckdb_extension.gz",
+      "local_relpath": "backend/extensions/duckdb/v1.4.4/windows_amd64/spatial.duckdb_extension"
     }
   ]
 }

--- a/scripts/release/package_bundle.sh
+++ b/scripts/release/package_bundle.sh
@@ -28,12 +28,24 @@ if [ ! -f "$extension_path" ]; then
   exit 1
 fi
 
+# Detect if this is a Windows platform based on artifact_id
+is_windows=false
+if [[ "$artifact_id" == *"windows"* ]] || [[ "$artifact_id" == *"win"* ]]; then
+  is_windows=true
+fi
+
 bundle_name="mapflow-${version}-${artifact_id}"
 bundle_dir="$(mktemp -d)/${bundle_name}"
 mkdir -p "${bundle_dir}/extensions"
 
-cp "$binary_path" "${bundle_dir}/mapflow"
-chmod +x "${bundle_dir}/mapflow"
+# Copy binary with appropriate name and extension
+if [ "$is_windows" = true ]; then
+  cp "$binary_path" "${bundle_dir}/mapflow.exe"
+else
+  cp "$binary_path" "${bundle_dir}/mapflow"
+  chmod +x "${bundle_dir}/mapflow"
+fi
+
 cp -R frontend/dist "${bundle_dir}/dist"
 cp "$extension_path" "${bundle_dir}/extensions/spatial.duckdb_extension"
 cp backend/extensions/spatial-extension-manifest.json "${bundle_dir}/spatial-extension-manifest.json"
@@ -42,7 +54,15 @@ cp LICENSE "${bundle_dir}/LICENSE"
 cp NOTICE "${bundle_dir}/NOTICE"
 
 mkdir -p "$output_dir"
-archive_path="${output_dir}/${bundle_name}.tar.gz"
-tar -C "$(dirname "${bundle_dir}")" -czf "${archive_path}" "${bundle_name}"
+
+# Create archive with appropriate format
+if [ "$is_windows" = true ]; then
+  archive_path="${output_dir}/${bundle_name}.zip"
+  # Use zip for Windows; -r for recursive, -q for quiet
+  (cd "$(dirname "${bundle_dir}")" && zip -r -q "${archive_path}" "${bundle_name}")
+else
+  archive_path="${output_dir}/${bundle_name}.tar.gz"
+  tar -C "$(dirname "${bundle_dir}")" -czf "${archive_path}" "${bundle_name}"
+fi
 
 echo "archive_path=${archive_path}"


### PR DESCRIPTION
## Summary

- Add Windows (x86_64) binary builds to release and nightly workflows
- Add `windows_amd64` platform to spatial extension manifest
- Update `package_bundle.sh` to detect Windows platform and produce `.zip` archives with `.exe` suffix
- Add Windows build matrix entry in `release.yml` and `nightly.yml`
- Install protobuf via chocolatey on Windows runners
- Update README with Windows download and usage instructions

## Test plan

- [ ] Verify GitHub Actions workflow runs successfully for Windows build
- [ ] Check that Windows artifact is uploaded as `.zip` file
- [ ] Confirm release includes `mapflow-*-windows-amd64.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)