### PR TITLE
fix(ci): fix Windows binary builds in nightly/release workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,7 +163,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: ${{ matrix.rust_target }}
+          target: ${{ matrix.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -179,7 +179,7 @@ jobs:
 
       - name: Install protobuf compiler (Windows)
         if: runner.os == 'Windows'
-        run: choco install protobuf -y
+        run: choco install protoc -y
 
       - name: Prepare spatial extension for binary embedding
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: ${{ matrix.rust_target }}
+          target: ${{ matrix.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install protobuf compiler (Windows)
         if: runner.os == 'Windows'
-        run: choco install protobuf -y
+        run: choco install protoc -y
 
       - name: Prepare spatial extension for binary embedding
         shell: bash

--- a/scripts/release/package_bundle.sh
+++ b/scripts/release/package_bundle.sh
@@ -45,7 +45,9 @@ mkdir -p "$output_dir"
 if [ "$is_windows" = true ]; then
   archive_path="${output_dir}/${bundle_name}.zip"
   # Use zip for Windows; -r for recursive, -q for quiet
-  (cd "$(dirname "${bundle_dir}")" && zip -r -q "${archive_path}" "${bundle_name}")
+  # Convert to absolute path before cd to avoid path resolution issues
+  abs_archive_path="$(cd "$(dirname "$archive_path")" && pwd)/$(basename "$archive_path")"
+  (cd "$(dirname "${bundle_dir}")" && zip -r -q "${abs_archive_path}" "${bundle_name}")
 else
   archive_path="${output_dir}/${bundle_name}.tar.gz"
   tar -C "$(dirname "${bundle_dir}")" -czf "${archive_path}" "${bundle_name}"


### PR DESCRIPTION
## Summary

- Fix wrong Chocolatey package name: `protobuf` → `protoc`
- Fix wrong action parameter: `targets` → `target`
- Fix `package_bundle.sh` zip path resolution bug for Windows builds

## Details

Three bugs were preventing Windows binaries from being released since PR #107:

1. **Chocolatey package name**: The package `protobuf` doesn't exist in the Chocolatey repository. The correct package is `protoc`.

2. **GitHub Action parameter**: `actions-rust-lang/setup-rust-toolchain` expects `target` (singular), not `targets`.

3. **zip path bug**: In `package_bundle.sh`, when the subshell cd's to a temp directory, the relative archive path becomes invalid, causing "No such file or directory" errors on macOS. Fixed by converting to absolute path before cd.