### PR TITLE
chore: increase default upload limit from 200MB to 1GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ mapflow.exe
 | `DB_PATH` | `./data/mapflow.duckdb` | DuckDB path |
 | `UPLOAD_DIR` | `./uploads` | Upload storage directory |
 | `WEB_DIST` | `frontend/dist` | Optional external frontend assets path (if missing, bundle binaries use embedded assets) |
-| `UPLOAD_MAX_SIZE_MB` | `200` | Upload max size |
+| `UPLOAD_MAX_SIZE_MB` | `1024` | Upload max size |
 | `COOKIE_SECURE` | `false` | Set `true` behind HTTPS |
 | `CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated CORS allowlist |
 | `SPATIAL_EXTENSION_PATH` | unset | Explicit local spatial extension path |

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,4 +1,4 @@
-const DEFAULT_MAX_SIZE_MB: u64 = 200;
+const DEFAULT_MAX_SIZE_MB: u64 = 1024;
 const BYTES_PER_MB: u64 = 1024 * 1024;
 
 /// Read CORS allowed origins from environment variable

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -228,13 +228,13 @@ mod tests {
             .lock()
             .expect("env lock");
 
-        let default_mb: u64 = 200;
+        let default_mb: u64 = 1024;
         let bytes_per_mb: u64 = 1024 * 1024;
 
         std::env::remove_var("UPLOAD_MAX_SIZE_MB");
         let (bytes, label) = read_max_size_config();
         assert_eq!(bytes, default_mb * bytes_per_mb);
-        assert_eq!(label, "200MB");
+        assert_eq!(label, "1GB");
 
         std::env::set_var("UPLOAD_MAX_SIZE_MB", "12");
         let (bytes, label) = read_max_size_config();
@@ -244,12 +244,12 @@ mod tests {
         std::env::set_var("UPLOAD_MAX_SIZE_MB", "0");
         let (bytes, label) = read_max_size_config();
         assert_eq!(bytes, default_mb * bytes_per_mb);
-        assert_eq!(label, "200MB");
+        assert_eq!(label, "1GB");
 
         std::env::set_var("UPLOAD_MAX_SIZE_MB", "nope");
         let (bytes, label) = read_max_size_config();
         assert_eq!(bytes, default_mb * bytes_per_mb);
-        assert_eq!(label, "200MB");
+        assert_eq!(label, "1GB");
         std::env::remove_var("UPLOAD_MAX_SIZE_MB");
     }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1220,7 +1220,7 @@ export default function App() {
           <h2>上传文件</h2>
           <span className="panel-meta">
             支持 .zip / .geojson / .geojsonl / .kml / .gpx / .topojson / .mbtiles，单文件最大
-            200MB（可配置）
+            1GB（可配置）
           </span>
         </div>
 


### PR DESCRIPTION
## Summary

- Increase default upload limit from 200MB to 1GB to better accommodate larger geospatial datasets
- Update all related documentation, UI hints, and tests to reflect the new default

## Changes

- `backend/src/config.rs`: Change `DEFAULT_MAX_SIZE_MB` from 200 to 1024
- `backend/src/lib.rs`: Update test assertions to expect "1GB" label
- `frontend/src/App.jsx`: Update UI hint text
- `README.md`: Update configuration documentation

The upload limit remains configurable via `UPLOAD_MAX_SIZE_MB` environment variable.