### PR TITLE
fix(db): add cfg guard for unused imports when embed-spatial-extension enabled

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -2,12 +2,14 @@
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(not(feature = "embed-spatial-extension"))]
+use std::sync::{Mutex as StdMutex, OnceLock};
+#[cfg(not(feature = "embed-spatial-extension"))]
 use std::time::Duration;
 #[cfg(feature = "embed-spatial-extension")]
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     path::{Path, PathBuf},
-    sync::{Arc, Mutex as StdMutex, OnceLock},
+    sync::Arc,
 };
 
 use tokio::sync::Mutex;


### PR DESCRIPTION
## Summary
- Add `#[cfg(not(feature = "embed-spatial-extension"))]` guard for `Mutex` and `OnceLock` imports that are only used when the embed-spatial-extension feature is disabled
- CI builds with `--features embed-spatial-extension`, causing unused import warnings treated as errors due to `RUSTFLAGS: -D warnings`

## Context
Fixes nightly workflow failure caused by PR #120 which changed version to 0.0.1 but didn't account for conditional imports.