### PR TITLE
fix(build): pass empty macros to embed_resource::compile

### DIFF
--- a/backend/build.rs
+++ b/backend/build.rs
@@ -1,4 +1,4 @@
 fn main() {
     #[cfg(windows)]
-    embed_resource::compile("mapflow.rc");
+    embed_resource::compile("mapflow.rc", embed_resource::NONE);
 }


### PR DESCRIPTION
## Summary
- Fix Windows build by passing empty array as second argument to `embed_resource::compile`
- The `embed-resource` crate version 2.5.2 changed its API to require a second `macros` argument

## Context
Fixes Windows binary build failure in nightly workflow.