### PR TITLE
feat(ci): add Linux ARM64 binary builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -135,6 +135,10 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
             artifact_id: linux-amd64
             duckdb_platform: linux_amd64
+          - os: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            artifact_id: linux-arm64
+            duckdb_platform: linux_arm64
           - os: macos-14
             rust_target: aarch64-apple-darwin
             artifact_id: darwin-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,10 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
             artifact_id: linux-amd64
             duckdb_platform: linux_amd64
+          - os: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            artifact_id: linux-arm64
+            duckdb_platform: linux_arm64
           - os: macos-14
             rust_target: aarch64-apple-darwin
             artifact_id: darwin-arm64


### PR DESCRIPTION
## Summary

- Add `linux-arm64` target to both nightly and release workflows
- Uses GitHub-hosted `ubuntu-24.04-arm` runner
- Rust target: `aarch64-unknown-linux-gnu`
- DuckDB spatial extension: `linux_arm64` (already in manifest)

## Notes

- Windows ARM64 is not included due to missing DuckDB spatial extension (`windows_arm64`) from upstream
- Docker builds already support linux/arm64 via the existing `docker_build` matrix