### PR TITLE
feat(preview): add OSM basemap toggle for standard CRS

### DIFF
--- a/docs/dev/behaviors.md
+++ b/docs/dev/behaviors.md
@@ -74,6 +74,7 @@
 | UI-011 | Detail Sidebar 选项卡 | Detail Sidebar 包含三个选项卡：Basic Info（基本信息）、Fields（字段表格）、Publish（发布设置）。非 ready 状态时 Fields/Publish 显示提示信息 | 选项卡导航正常，内容切换正确 | `frontend/tests/field-alias.spec.js frontend/tests/publish.spec.js` | E2E | P2 |
 | UI-012 | 字段别名显示 | Preview 页面特征检查器显示字段别名。有别名的字段显示为：别名 + 灰色小字原始名；无别名时仅显示原始名。通过 API-005 获取 alias 字段 | 有别名正确显示别名+原始名，无别名仅显示原始名 | `frontend/tests/field-alias.spec.js` | E2E | P1 |
 | UI-013 | 瓦片文档页 | /tiles/:slug/docs **无需认证**，显示已发布瓦片服务的完整文档：服务URL（可复制）、配置信息、OpenLayers代码示例、实时地图预览。支持标准CRS和自定义CRS | 文档正确显示，代码可复制，地图预览正常加载 | 手动验证 | E2E | P2 |
+| UI-014 | OSM 底图叠加开关 | Preview 页面在 `crsType=standard` 时显示 `Show OSM Basemap` 开关（默认关闭）。开启后 OSM 底图显示在数据图层下方；关闭后隐藏。切换不改变当前视角和已选中特征。`crsType=custom` 时不显示开关且不请求 OSM 瓦片 | standard 数据可切换 OSM 底图；custom 数据无开关且无 OSM 请求 | `frontend/tests/preview.spec.js` + `frontend/tests/custom-crs.spec.js` | E2E | P1 |
 | E2E-001 | 完整上传（GeoJSON） | 上传 .geojson → 列表更新 → ready → 详情可访问 → 预览打开地图 | 端到端流程成功 | `frontend/tests/upload.spec.js frontend/tests/preview.spec.js` | E2E | P0 |
 | E2E-002 | 完整上传（Shapefile） | 上传 .zip（.shp/.shx/.dbf）→ 列表更新 → ready → 详情可访问 → 预览打开地图 | 端到端流程成功 | `frontend/tests/upload.spec.js` | E2E | P0 |
 | E2E-003 | 完整上传（GeoJSONSeq） | 上传 .geojsonl → 列表更新 → ready → schema 查询 → 瓦片端点验证成功 | 端到端流程成功 | `frontend/tests/upload-formats.spec.js` | E2E | P0 |

--- a/frontend/src/Preview.jsx
+++ b/frontend/src/Preview.jsx
@@ -15,6 +15,7 @@ import VectorTileLayer from 'ol/layer/VectorTile';
 import VectorTileSource from 'ol/source/VectorTile';
 import TileLayer from 'ol/layer/Tile';
 import TileSource from 'ol/source/Tile';
+import OSM from 'ol/source/OSM';
 import TileDebug from 'ol/source/TileDebug';
 import MVT from 'ol/format/MVT';
 import Projection from 'ol/proj/Projection';
@@ -53,7 +54,9 @@ export default function Preview() {
   const tileFormatRef = useRef(null);
   const loadFeaturePropertiesRef = useRef(async () => {});
   const [showTileGrid, setShowTileGrid] = useState(false);
+  const [showOsmBasemap, setShowOsmBasemap] = useState(false);
   const tileGridLayerRef = useRef(null);
+  const osmLayerRef = useRef(null);
   const [tileFormat, setTileFormat] = useState(null);
 
   const cancelPopup = useCallback(() => {
@@ -274,6 +277,7 @@ export default function Preview() {
       }),
       visible: false,
     });
+    tileGridLayer.setZIndex(20);
     tileGridLayerRef.current = tileGridLayer;
     olMap.addLayer(tileGridLayer);
 
@@ -281,6 +285,7 @@ export default function Preview() {
       olMap.setTarget(null);
       mapRef.current = null;
       vectorLayerRef.current = null;
+      osmLayerRef.current = null;
       tileGridLayerRef.current = null;
     };
   }, [cancelPopup]);
@@ -362,10 +367,10 @@ export default function Preview() {
         style: styleFunction,
       });
     }
+    tileLayer.setZIndex(10);
 
     vectorLayerRef.current = tileLayer;
-    // Insert vector layer at index 0, tile grid stays on top
-    map.getLayers().insertAt(0, tileLayer);
+    map.addLayer(tileLayer);
 
     // 2. Update View projection for custom CRS
     if (isCustomCRS && customProjection) {
@@ -404,6 +409,39 @@ export default function Preview() {
       });
     }
   }, [meta, id, styleFunction, tileFormat]);
+
+  // Toggle OSM basemap visibility for standard CRS only.
+  useEffect(() => {
+    if (!mapRef.current) return;
+
+    const map = mapRef.current;
+    const canOverlayOsm = meta?.crsType === 'standard';
+
+    if (!canOverlayOsm) {
+      const existingOsmLayer = osmLayerRef.current;
+      if (existingOsmLayer) {
+        map.removeLayer(existingOsmLayer);
+        osmLayerRef.current = null;
+      }
+      return;
+    }
+
+    if (!showOsmBasemap) {
+      osmLayerRef.current?.setVisible(false);
+      return;
+    }
+
+    if (!osmLayerRef.current) {
+      const osmLayer = new TileLayer({
+        source: new OSM(),
+      });
+      osmLayer.setZIndex(0);
+      map.addLayer(osmLayer);
+      osmLayerRef.current = osmLayer;
+    }
+
+    osmLayerRef.current.setVisible(true);
+  }, [meta, showOsmBasemap]);
 
   // Toggle tile grid visibility
   useEffect(() => {
@@ -500,25 +538,46 @@ export default function Preview() {
           </div>
         )}
 
-        {/* Tile Grid Toggle */}
-        <label
-          style={{
-            marginLeft: 'auto',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '6px',
-            fontSize: '13px',
-            cursor: 'pointer',
-            userSelect: 'none',
-          }}
-        >
-          <input
-            type="checkbox"
-            checked={showTileGrid}
-            onChange={(e) => setShowTileGrid(e.target.checked)}
-          />
-          Show Tile Grid
-        </label>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '16px' }}>
+          {meta?.crsType === 'standard' && (
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+                fontSize: '13px',
+                cursor: 'pointer',
+                userSelect: 'none',
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={showOsmBasemap}
+                onChange={(e) => setShowOsmBasemap(e.target.checked)}
+              />
+              Show OSM Basemap
+            </label>
+          )}
+
+          {/* Tile Grid Toggle */}
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              fontSize: '13px',
+              cursor: 'pointer',
+              userSelect: 'none',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={showTileGrid}
+              onChange={(e) => setShowTileGrid(e.target.checked)}
+            />
+            Show Tile Grid
+          </label>
+        </div>
       </header>
 
       <div style={{ flex: '1 1 auto', position: 'relative', overflow: 'hidden' }}>

--- a/frontend/tests/custom-crs.spec.js
+++ b/frontend/tests/custom-crs.spec.js
@@ -282,4 +282,49 @@ test.describe('Custom CRS', () => {
 
     await publicContext.close();
   });
+
+  test('custom CRS preview hides OSM basemap toggle and does not request OSM tiles', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120000);
+
+    const testFile = path.join(customCrsDir, 'sf_buildings_no_crs.geojson');
+
+    await page.goto('/');
+    await page.getByTestId('file-input').setInputFiles(testFile);
+
+    await expect(
+      page.locator('.row', { hasText: 'sf_buildings_no_crs' }).getByText(/已就绪|等待处理/),
+    ).toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get('/api/files');
+          if (!response.ok()) return null;
+          const files = await response.json();
+          const file = files.find((f) => f.name === 'sf_buildings_no_crs');
+          return file?.status;
+        },
+        { message: 'wait for file to be ready', timeout: 60000 },
+      )
+      .toBe('ready');
+
+    const row = page.locator('.row', { hasText: 'sf_buildings_no_crs' });
+    const previewLink = row.getByRole('link', { name: '查看' });
+
+    let osmRequestCount = 0;
+    await page.context().route('https://tile.openstreetmap.org/**', async (route) => {
+      osmRequestCount += 1;
+      await route.abort();
+    });
+
+    const [newPage] = await Promise.all([page.context().waitForEvent('page'), previewLink.click()]);
+    await newPage.waitForLoadState('networkidle');
+
+    await expect(newPage.getByLabel('Show OSM Basemap')).toHaveCount(0);
+    await newPage.waitForTimeout(1500);
+    expect(osmRequestCount).toBe(0);
+  });
 });

--- a/frontend/tests/preview.spec.js
+++ b/frontend/tests/preview.spec.js
@@ -189,3 +189,55 @@ test('click feature switches highlight style immediately', async ({ page, reques
   expect(normalizeColor(nonSelectedStyle.strokeColor)).toBe('#0080ff');
   expect(nonSelectedStyle.strokeWidth).toBe(2);
 });
+
+test('standard CRS preview shows OSM basemap toggle and requests OSM tiles when enabled', async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120000);
+
+  const fixturesDir = path.join(__dirname, 'fixtures');
+  const geojsonPath = path.join(fixturesDir, 'sample.geojson');
+
+  await page.goto('/');
+  await page.getByTestId('file-input').setInputFiles(geojsonPath);
+
+  await expect(
+    page.locator('.row', { hasText: 'sample' }).getByText(/已就绪|等待处理/),
+  ).toBeVisible();
+
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get('/api/files');
+        if (!response.ok()) return null;
+        const files = await response.json();
+        return files.find((f) => f.name === 'sample')?.status ?? null;
+      },
+      { message: 'wait for file to be ready', timeout: 60000 },
+    )
+    .toBe('ready');
+
+  const row = page.locator('.row', { hasText: 'sample' });
+  const previewLink = row.getByRole('link', { name: '查看' });
+  await expect(previewLink).toBeVisible();
+
+  let osmRequestCount = 0;
+  await page.context().route('https://tile.openstreetmap.org/**', async (route) => {
+    osmRequestCount += 1;
+    await route.abort();
+  });
+
+  const [newPage] = await Promise.all([page.context().waitForEvent('page'), previewLink.click()]);
+  await newPage.waitForLoadState('networkidle');
+
+  const osmToggle = newPage.getByLabel('Show OSM Basemap');
+  await expect(osmToggle).toBeVisible();
+  await expect(osmToggle).not.toBeChecked();
+
+  await osmToggle.check();
+
+  await expect
+    .poll(() => osmRequestCount, { message: 'wait for OSM tile requests', timeout: 10000 })
+    .toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- add Show OSM Basemap toggle in preview header for crsType=standard datasets only
- keep toggle hidden for crsType=custom datasets
- render OSM layer under data layer and keep tile-grid overlay on top
- preserve current view/interaction behavior while toggling basemap

## Contract
- add behavior contract UI-014 in docs/dev/behaviors.md

## Tests
- add e2e: standard CRS shows OSM toggle and triggers OSM tile requests when enabled
- add e2e: custom CRS hides OSM toggle and triggers no OSM tile requests
- full pre-push suite passed locally (backend + frontend unit + frontend e2e)
