### PR TITLE
fix: align preview tile grid with custom CRS tile scheme

### DIFF
--- a/docs/dev/behaviors.md
+++ b/docs/dev/behaviors.md
@@ -75,6 +75,7 @@
 | UI-012 | 字段别名显示 | Preview 页面特征检查器显示字段别名。有别名的字段显示为：别名 + 灰色小字原始名；无别名时仅显示原始名。通过 API-005 获取 alias 字段 | 有别名正确显示别名+原始名，无别名仅显示原始名 | `frontend/tests/field-alias.spec.js` | E2E | P1 |
 | UI-013 | 瓦片文档页 | /tiles/:slug/docs **无需认证**，显示已发布瓦片服务的完整文档：服务URL（可复制）、配置信息、OpenLayers代码示例、实时地图预览。支持标准CRS和自定义CRS | 文档正确显示，代码可复制，地图预览正常加载 | 手动验证 | E2E | P2 |
 | UI-014 | OSM 底图叠加开关 | Preview 页面在 `crsType=standard` 时显示 `Show OSM Basemap` 开关（默认关闭）。开启后 OSM 底图显示在数据图层下方；关闭后隐藏。切换不改变当前视角和已选中特征。`crsType=custom` 时不显示开关且不请求 OSM 瓦片 | standard 数据可切换 OSM 底图；custom 数据无开关且无 OSM 请求 | `frontend/tests/preview.spec.js` + `frontend/tests/custom-crs.spec.js` | E2E | P1 |
+| UI-015 | 预览页 Tile Grid 对齐 | /preview/:id 保持 `Show Tile Grid` 手动开关（默认关闭）。当文件 `crsType=custom` 且存在 `dataBounds` 时，开启后网格必须使用 custom tile grid（与数据图层相同 extent/origin/resolutions）并与瓦片坐标系对齐 | 勾选开关后，TileDebug 图层可见且使用 custom tile grid；标准 CRS 路径不回归 | `frontend/tests/custom-crs.spec.js` | E2E | P1 |
 | E2E-001 | 完整上传（GeoJSON） | 上传 .geojson → 列表更新 → ready → 详情可访问 → 预览打开地图 | 端到端流程成功 | `frontend/tests/upload.spec.js frontend/tests/preview.spec.js` | E2E | P0 |
 | E2E-002 | 完整上传（Shapefile） | 上传 .zip（.shp/.shx/.dbf）→ 列表更新 → ready → 详情可访问 → 预览打开地图 | 端到端流程成功 | `frontend/tests/upload.spec.js` | E2E | P0 |
 | E2E-003 | 完整上传（GeoJSONSeq） | 上传 .geojsonl → 列表更新 → ready → schema 查询 → 瓦片端点验证成功 | 端到端流程成功 | `frontend/tests/upload-formats.spec.js` | E2E | P0 |

--- a/docs/dev/todo.md
+++ b/docs/dev/todo.md
@@ -184,6 +184,15 @@
 
 **Scope**: 单文件预览，不支持发布公开瓦片
 
+### Preview Tile Grid Alignment (2026-03-03)
+
+- **Issue**: Preview 页 `TileDebug` 图层在初始化时使用默认 source，custom CRS 场景未绑定 custom `tileGrid`，导致网格显示错位或不显示。
+- **Root Cause**: `Show Tile Grid` 仅切换图层可见性，但没有在 `meta` 变化后同步 `TileDebug` 的 projection/tileGrid。
+- **Fix**:
+  - 在 `Preview.jsx` 中复用 custom CRS 数据图层的 `Projection` + `TileGrid` 配置更新 `TileDebug` source
+  - 保持 `Show Tile Grid` 手动开关默认关闭，不改 UX
+  - 新增 E2E 可观测断言验证 `TileDebug` 图层对 custom CRS 的 `extent/origin/resolutions`
+
 ### User Story
 
 1. 用户上传本地坐标系数据（无 EPSG code）
@@ -258,6 +267,7 @@ ST_Read_Meta 结果 → 归一化 + 分类
   - resolutions = 计算 z=0 到 z=20
 - [x] 创建 Projection: code, units='m', extent
 - [x] 显示 custom CRS 标签（橙色样式）
+- [x] TileDebug 图层复用 custom `tileGrid`，确保 Preview 勾选 `Show Tile Grid` 后网格与 custom CRS 瓦片对齐
 
 #### 4. Test Data
 
@@ -277,6 +287,7 @@ ST_Read_Meta 结果 → 归一化 + 分类
 - [x] E2E: 自定义 CRS 上传流程 (custom-crs.spec.js)
 - [x] E2E: 自定义 CRS 瓦片请求
 - [x] E2E: 预览页正常显示
+- [x] E2E: `Show Tile Grid` 在 custom CRS 下使用正确的 `extent/origin/resolutions`
 - [x] Integration: PUT /api/files/:id/crs (6 tests)
 
 #### 6. Future Test Data (Optional)

--- a/frontend/src/Preview.jsx
+++ b/frontend/src/Preview.jsx
@@ -36,6 +36,20 @@ function calculateCustomResolutions(dataBounds, maxZoom = 20) {
   return Array.from({ length: maxZoom + 1 }, (_, z) => maxDim / (256 * Math.pow(2, z)));
 }
 
+function createTileDebugSource(projection = 'EPSG:3857', tileGrid = null) {
+  const options = {
+    template: 'z:{z} x:{x} y:{y}',
+    zDirection: 1,
+    projection,
+  };
+
+  if (tileGrid) {
+    options.tileGrid = tileGrid;
+  }
+
+  return new TileDebug(options);
+}
+
 export default function Preview() {
   const { id } = useParams();
   const mapElement = useRef(null);
@@ -207,8 +221,9 @@ export default function Preview() {
   useEffect(() => {
     if (!mapElement.current || mapRef.current) return;
 
+    const targetElement = mapElement.current;
     const olMap = new OLMap({
-      target: mapElement.current,
+      target: targetElement,
       view: new View({
         center: fromLonLat([0, 0]),
         zoom: 2,
@@ -219,6 +234,8 @@ export default function Preview() {
     });
 
     mapRef.current = olMap;
+    targetElement.__mapflowPreviewMap = olMap;
+    window.__mapflowPreviewMap = olMap;
 
     // Click handler for features
     olMap.on('click', (evt) => {
@@ -271,13 +288,11 @@ export default function Preview() {
 
     // Add Tile Grid debug layer (initially hidden)
     const tileGridLayer = new TileLayer({
-      source: new TileDebug({
-        template: 'z:{z} x:{x} y:{y}',
-        zDirection: 1,
-      }),
+      source: createTileDebugSource(),
       visible: false,
     });
     tileGridLayer.setZIndex(20);
+    tileGridLayer.set('mapflowRole', 'tile-grid-debug');
     tileGridLayerRef.current = tileGridLayer;
     olMap.addLayer(tileGridLayer);
 
@@ -287,6 +302,10 @@ export default function Preview() {
       vectorLayerRef.current = null;
       osmLayerRef.current = null;
       tileGridLayerRef.current = null;
+      delete targetElement.__mapflowPreviewMap;
+      if (window.__mapflowPreviewMap === olMap) {
+        delete window.__mapflowPreviewMap;
+      }
     };
   }, [cancelPopup]);
 
@@ -372,7 +391,12 @@ export default function Preview() {
     vectorLayerRef.current = tileLayer;
     map.addLayer(tileLayer);
 
-    // 2. Update View projection for custom CRS
+    // Keep TileDebug source aligned with the same tile scheme as data tiles.
+    tileGridLayerRef.current?.setSource(
+      createTileDebugSource(customProjection || 'EPSG:3857', customTileGrid),
+    );
+
+    // 2. Update View projection
     if (isCustomCRS && customProjection) {
       const [minx, miny, maxx, maxy] = meta.dataBounds;
       const centerX = (minx + maxx) / 2;
@@ -383,6 +407,16 @@ export default function Preview() {
           projection: customProjection,
           center: [centerX, centerY],
           zoom: 0,
+          minZoom: minZoom,
+          maxZoom: maxZoom,
+        }),
+      );
+    } else {
+      map.setView(
+        new View({
+          projection: 'EPSG:3857',
+          center: fromLonLat([0, 0]),
+          zoom: 2,
           minZoom: minZoom,
           maxZoom: maxZoom,
         }),

--- a/frontend/tests/custom-crs.spec.js
+++ b/frontend/tests/custom-crs.spec.js
@@ -5,6 +5,70 @@ import { loginUser, setupTestUser } from './auth-helper.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const customCrsDir = path.join(__dirname, '..', '..', 'testdata', 'custom-crs');
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+async function waitForFileReady(request, name) {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get('/api/files');
+        if (!response.ok()) return null;
+        const files = await response.json();
+        const file = files.find((item) => item.name === name);
+        return file?.status;
+      },
+      { message: `wait for ${name} to be ready`, timeout: 60000 },
+    )
+    .toBe('ready');
+}
+
+async function getFileByName(request, name) {
+  const response = await request.get('/api/files');
+  expect(response.ok()).toBeTruthy();
+  const files = await response.json();
+  return files.find((item) => item.name === name);
+}
+
+async function readTileGridDebugState(previewPage) {
+  return previewPage.evaluate(() => {
+    const mapElement =
+      document.querySelector('[data-testid="preview-map-canvas"]') ||
+      document.querySelector('[data-testid="preview-map"]');
+    const map = mapElement?.__mapflowPreviewMap || window.__mapflowPreviewMap;
+    if (!map) {
+      return { hasMap: false, hasDebugLayer: false };
+    }
+
+    const layers = map.getLayers().getArray();
+    const debugLayer = layers.find((layer) => layer?.get?.('mapflowRole') === 'tile-grid-debug');
+    if (!debugLayer) {
+      return { hasMap: true, hasDebugLayer: false };
+    }
+
+    const source = debugLayer.getSource();
+    const tileGrid = source?.getTileGrid?.();
+    const projection = source?.getProjection?.();
+    const projectionCode =
+      projection && typeof projection.getCode === 'function' ? projection.getCode() : projection;
+    const extent =
+      tileGrid && typeof tileGrid.getExtent === 'function' ? tileGrid.getExtent() : null;
+    const origin =
+      tileGrid && typeof tileGrid.getOrigin === 'function' ? tileGrid.getOrigin(0) : null;
+    const resolutions =
+      tileGrid && typeof tileGrid.getResolutions === 'function' ? tileGrid.getResolutions() : null;
+
+    return {
+      hasMap: true,
+      hasDebugLayer: true,
+      visible: debugLayer.getVisible(),
+      hasTileGrid: !!tileGrid,
+      extent,
+      origin,
+      resolutionCount: Array.isArray(resolutions) ? resolutions.length : null,
+      projectionCode,
+    };
+  });
+}
 
 test.describe('Custom CRS', () => {
   test.beforeEach(async ({ workerServer, request }) => {
@@ -188,6 +252,118 @@ test.describe('Custom CRS', () => {
 
     expect(previewData.bbox[0]).toBeLessThan(0);
     expect(previewData.bbox[1]).toBeLessThan(0);
+  });
+
+  test('custom CRS preview tile grid uses custom tile grid configuration', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120000);
+
+    const testFile = path.join(customCrsDir, 'sf_buildings_no_crs.geojson');
+
+    await page.goto('/');
+    await page.getByTestId('file-input').setInputFiles(testFile);
+
+    await expect(
+      page.locator('.row', { hasText: 'sf_buildings_no_crs' }).getByText(/已就绪|等待处理/),
+    ).toBeVisible();
+
+    await waitForFileReady(request, 'sf_buildings_no_crs');
+
+    const fileData = await getFileByName(request, 'sf_buildings_no_crs');
+    expect(fileData).toBeDefined();
+
+    const previewMetaResponse = await request.get(`/api/files/${fileData.id}/preview`);
+    expect(previewMetaResponse.ok()).toBeTruthy();
+    const previewMeta = await previewMetaResponse.json();
+    expect(previewMeta.crsType).toBe('custom');
+    expect(previewMeta.dataBounds).toHaveLength(4);
+
+    const row = page.locator('.row', { hasText: 'sf_buildings_no_crs' });
+    const previewLink = row.getByRole('link', { name: '查看' });
+    await expect(previewLink).toBeVisible();
+
+    const [previewPage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      previewLink.click(),
+    ]);
+    await previewPage.waitForLoadState('networkidle');
+    await expect(previewPage.getByText('sf_buildings_no_crs')).toBeVisible();
+
+    await previewPage.getByLabel('Show Tile Grid').check();
+
+    await expect
+      .poll(
+        async () => {
+          const state = await readTileGridDebugState(previewPage);
+          return state.visible;
+        },
+        { message: 'wait for tile grid debug layer to become visible', timeout: 10000 },
+      )
+      .toBe(true);
+
+    const state = await readTileGridDebugState(previewPage);
+    expect(state.hasMap).toBe(true);
+    expect(state.hasDebugLayer).toBe(true);
+    expect(state.hasTileGrid).toBe(true);
+    expect(state.resolutionCount).toBe(21);
+    expect(state.projectionCode).toBe(previewMeta.crs || 'CUSTOM_CRS');
+
+    const [minx, miny, maxx, maxy] = previewMeta.dataBounds;
+    expect(state.extent[0]).toBeCloseTo(minx, 6);
+    expect(state.extent[1]).toBeCloseTo(miny, 6);
+    expect(state.extent[2]).toBeCloseTo(maxx, 6);
+    expect(state.extent[3]).toBeCloseTo(maxy, 6);
+    expect(state.origin[0]).toBeCloseTo(minx, 6);
+    expect(state.origin[1]).toBeCloseTo(maxy, 6);
+
+    await previewPage.close();
+  });
+
+  test('standard CRS preview tile grid toggle still works', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    const testFile = path.join(fixturesDir, 'sample.geojson');
+
+    await page.goto('/');
+    await page.getByTestId('file-input').setInputFiles(testFile);
+
+    await expect(
+      page.locator('.row', { hasText: 'sample' }).getByText(/已就绪|等待处理/),
+    ).toBeVisible();
+    await waitForFileReady(request, 'sample');
+
+    const row = page.locator('.row', { hasText: 'sample' });
+    const previewLink = row.getByRole('link', { name: '查看' });
+    await expect(previewLink).toBeVisible();
+
+    const [previewPage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      previewLink.click(),
+    ]);
+    await previewPage.waitForLoadState('networkidle');
+    await expect(previewPage.getByText('sample')).toBeVisible();
+
+    await previewPage.getByLabel('Show Tile Grid').check();
+    await expect
+      .poll(
+        async () => {
+          const state = await readTileGridDebugState(previewPage);
+          return state.visible;
+        },
+        {
+          message: 'wait for standard CRS tile grid debug layer to become visible',
+          timeout: 10000,
+        },
+      )
+      .toBe(true);
+
+    const state = await readTileGridDebugState(previewPage);
+    expect(state.hasMap).toBe(true);
+    expect(state.hasDebugLayer).toBe(true);
+
+    await previewPage.close();
   });
 
   test('update CRS with EPSG URN (4490) and verify docs tile requests', async ({


### PR DESCRIPTION
## Summary
- align `/preview/:id` tile-grid debug overlay with the same custom CRS tile scheme used by data tiles
- keep `Show Tile Grid` as a manual toggle (default off)
- add E2E coverage for custom CRS tile-grid configuration and standard CRS toggle regression
- update behavior/todo docs for the new observable contract

## Changes
- `frontend/src/Preview.jsx`
  - add `createTileDebugSource()` helper
  - rebuild TileDebug source on meta changes with custom `projection + tileGrid`
  - reset view projection for standard CRS path to avoid stale custom projection
  - expose map instance for E2E introspection (`data-testid=preview-map` + debug hook)
  - tag tile-grid debug layer with `mapflowRole=tile-grid-debug`
- `frontend/tests/custom-crs.spec.js`
  - add custom CRS assertion on TileDebug `extent/origin/resolutions`
  - add standard CRS tile-grid toggle regression test
- `docs/dev/behaviors.md`
  - add UI-014 contract for custom CRS tile-grid alignment on preview
- `docs/dev/todo.md`
  - record issue/root-cause/fix for preview tile-grid alignment

## Validation
- `npm --prefix frontend run test:e2e -- custom-crs.spec.js` (7 passed)
- pre-push full suite passed:
  - backend tests (unit + api)
  - `npm --prefix frontend run test:unit`
  - `npm --prefix frontend run test:e2e` (38 passed)
