### PR TITLE
Expand smoke coverage for MBTiles PNG scenario

### DIFF
--- a/docs/dev/todo.md
+++ b/docs/dev/todo.md
@@ -126,6 +126,13 @@
   - 验证：新增 `db::tests::ensure_spatial_extension_falls_back_after_local_load_failure`
   - 结果（2026-03-03）：✅ 通过
     - `cargo test --manifest-path backend/Cargo.toml ensure_spatial_extension_falls_back_after_local_load_failure -- --nocapture`
+- [x] S22: Smoke 覆盖补齐 MBTiles(PNG) 场景（schema 空数组 + 私有/公开瓦片 content-type）
+  - 验证：`smoke-binary` 与 `smoke-docker` 均覆盖 MVT+PNG 双场景
+  - 结果（2026-03-03）：✅ 通过
+    - `bash -n scripts/smoke/lib/common.sh scripts/smoke/smoke-binary.sh scripts/smoke/smoke-docker.sh`
+    - `bash scripts/smoke/smoke-binary.sh --binary ./target/debug/backend --port 3331 --expected-b64 /tmp/nonexistent-smoke-expected.b64`
+    - `docker build -t mapflow-smoke:mbtiles-png .`
+    - `bash scripts/smoke/smoke-docker.sh --image mapflow-smoke:mbtiles-png --port 3332 --expected-b64 /tmp/nonexistent-smoke-expected.b64`
 
 ## Known Issues
 
@@ -439,7 +446,7 @@ function calculateResolutions(bounds, maxZoom = 20) {
 待扩展：
 - [x] Shapefile 上传测试（`scripts/smoke/smoke-docker.sh --fixture frontend/tests/fixtures/roads.zip`）
 - [x] MBTiles 上传测试（MVT）（`scripts/smoke/smoke-binary.sh` / `scripts/smoke/smoke-docker.sh` 默认覆盖）
-- [ ] MBTiles 上传测试（PNG）
+- [x] MBTiles 上传测试（PNG）（`scripts/smoke/smoke-binary.sh` / `scripts/smoke/smoke-docker.sh` 默认覆盖；含 schema 空数组与 private/public `Content-Type: image/png` 断言）
 - [x] 错误场景：无效格式上传返回 400（`scripts/smoke/smoke-binary.sh` / `scripts/smoke/smoke-docker.sh`）
 - [x] 错误场景：超大文件（413）（`scripts/smoke/smoke-binary.sh` / `scripts/smoke/smoke-docker.sh`）
 - [x] Schema 查询验证（`scripts/smoke/smoke-binary.sh` / `scripts/smoke/smoke-docker.sh`）

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -18,12 +18,16 @@
 | 10. 获取瓦片 | 私有瓦片返回 MVT |
 | 11. 发布文件 | 公开 slug 分配成功 |
 | 12. 公开瓦片 | 无需认证访问瓦片 |
-| 13. 上传 MBTiles | MBTiles 上传成功 |
-| 14. MBTiles 元数据 | preview/meta 返回期望 `tileFormat` |
-| 15. MBTiles Schema 查询 | `/api/files/:id/schema` 返回有效图层 |
-| 16. MBTiles 特征属性 | `/api/files/:id/features/:fid` 返回 400（不支持） |
-| 17. MBTiles 发布 | 发布后 `tiles/:slug/meta` 返回期望 `tileFormat` |
-| 18. 错误场景 | 超大文件上传返回 413（File too large） |
+| 13. 上传 MBTiles(MVT) | MBTiles 上传成功 |
+| 14. MBTiles(MVT) 元数据 | preview/meta 返回 `tileFormat=mvt` |
+| 15. MBTiles(MVT) Schema 查询 | `/api/files/:id/schema` 返回有效图层 |
+| 16. MBTiles(MVT) 特征属性 | `/api/files/:id/features/:fid` 返回 400（不支持） |
+| 17. MBTiles(MVT) 发布 | 发布后 `tiles/:slug/meta` 返回 `tileFormat=mvt` |
+| 18. 上传 MBTiles(PNG) | MBTiles 上传成功 |
+| 19. MBTiles(PNG) 元数据 | preview/meta 返回 `tileFormat=png` |
+| 20. MBTiles(PNG) Schema 查询 | `/api/files/:id/schema` 返回空图层数组 |
+| 21. MBTiles(PNG) 瓦片类型 | 私有/公开瓦片 `Content-Type: image/png` |
+| 22. 错误场景 | 超大文件上传返回 413（File too large） |
 
 ## 使用方法
 
@@ -40,6 +44,8 @@
   --fixture frontend/tests/fixtures/sample.geojson \
   --mbtiles-fixture testdata/monaco_roads.mbtiles \
   --mbtiles-format mvt \
+  --mbtiles-png-fixture testdata/sample_png.mbtiles \
+  --mbtiles-png-format png \
   --expected-b64 testdata/smoke/expected_sample_z0_x0_y0.mvt.base64
 
 # 保留测试数据（调试用）
@@ -59,6 +65,8 @@ SMOKE_KEEP_DATA=true ./scripts/smoke/smoke-binary.sh --binary ./mapflow
   --fixture frontend/tests/fixtures/sample.geojson \
   --mbtiles-fixture testdata/monaco_roads.mbtiles \
   --mbtiles-format mvt \
+  --mbtiles-png-fixture testdata/sample_png.mbtiles \
+  --mbtiles-png-format png \
   --expected-b64 testdata/smoke/expected_sample_z0_x0_y0.mvt.base64
 ```
 
@@ -70,6 +78,8 @@ SMOKE_KEEP_DATA=true ./scripts/smoke/smoke-binary.sh --binary ./mapflow
 | `SMOKE_FIXTURE` | 测试文件路径 | `frontend/tests/fixtures/sample.geojson` |
 | `SMOKE_MBTILES_FIXTURE` | MBTiles 测试文件路径 | `testdata/monaco_roads.mbtiles` |
 | `SMOKE_MBTILES_EXPECTED_FORMAT` | MBTiles 期望 tileFormat | `mvt` |
+| `SMOKE_MBTILES_PNG_FIXTURE` | PNG MBTiles 测试文件路径 | `testdata/sample_png.mbtiles` |
+| `SMOKE_MBTILES_PNG_EXPECTED_FORMAT` | PNG MBTiles 期望 tileFormat | `png` |
 | `SMOKE_OVERSIZE_FIXTURE` | 超大文件测试路径（需大于限制） | `frontend/tests/fixtures/roads.zip` |
 | `SMOKE_OVERSIZE_LIMIT_MB` | 超大文件测试时临时限制（通过 `/api/settings` 下调） | 1 |
 | `SMOKE_CRS_UPDATE_INPUT` | CRS 更新请求值（PUT `/api/files/:id/crs`） | `urn:ogc:def:crs:EPSG::4490` |

--- a/scripts/smoke/lib/common.sh
+++ b/scripts/smoke/lib/common.sh
@@ -186,6 +186,105 @@ get_public_tile() {
   smoke_log "public tile size: ${size} bytes"
 }
 
+verify_private_tile_content_type() {
+  local base_url="$1"
+  local cookie_jar="$2"
+  local file_id="$3"
+  local expected_content_type="$4"
+  local z="${5:-0}"
+  local x="${6:-0}"
+  local y="${7:-0}"
+
+  smoke_log "verifying private tile content-type for file ${file_id} (${z}/${x}/${y})"
+
+  local response_file
+  response_file="$(mktemp)"
+  local headers_file
+  headers_file="$(mktemp)"
+
+  local http_code
+  http_code=$(curl -sS -o "$response_file" -D "$headers_file" -w "%{http_code}" -b "$cookie_jar" \
+    "${base_url}/api/files/${file_id}/tiles/${z}/${x}/${y}" || true)
+
+  if [ "$http_code" != "200" ]; then
+    local body
+    body="$(cat "$response_file" 2>/dev/null || true)"
+    rm -f "$response_file" "$headers_file"
+    smoke_fail "expected private tile status 200, got ${http_code}, body=${body}"
+  fi
+
+  python3 - "$headers_file" "$expected_content_type" <<'PY'
+import sys
+
+path, expected = sys.argv[1], sys.argv[2].lower()
+content_type = None
+with open(path, "r", encoding="utf-8", errors="ignore") as f:
+    for line in f:
+        if line.lower().startswith("content-type:"):
+            content_type = line.split(":", 1)[1].strip().lower()
+            break
+
+if content_type is None:
+    raise SystemExit("private tile content-type header missing")
+if not content_type.startswith(expected):
+    raise SystemExit(
+        f"private tile content-type mismatch: expected prefix {expected}, got {content_type}"
+    )
+PY
+
+  rm -f "$response_file" "$headers_file"
+  smoke_log "private tile content-type verified"
+}
+
+verify_public_tile_content_type() {
+  local base_url="$1"
+  local slug="$2"
+  local expected_content_type="$3"
+  local z="${4:-0}"
+  local x="${5:-0}"
+  local y="${6:-0}"
+
+  smoke_log "verifying public tile content-type for slug ${slug} (${z}/${x}/${y})"
+
+  local response_file
+  response_file="$(mktemp)"
+  local headers_file
+  headers_file="$(mktemp)"
+
+  local http_code
+  http_code=$(curl -sS -o "$response_file" -D "$headers_file" -w "%{http_code}" \
+    "${base_url}/tiles/${slug}/${z}/${x}/${y}" || true)
+
+  if [ "$http_code" != "200" ]; then
+    local body
+    body="$(cat "$response_file" 2>/dev/null || true)"
+    rm -f "$response_file" "$headers_file"
+    smoke_fail "expected public tile status 200, got ${http_code}, body=${body}"
+  fi
+
+  python3 - "$headers_file" "$expected_content_type" <<'PY'
+import sys
+
+path, expected = sys.argv[1], sys.argv[2].lower()
+content_type = None
+with open(path, "r", encoding="utf-8", errors="ignore") as f:
+    for line in f:
+        if line.lower().startswith("content-type:"):
+            content_type = line.split(":", 1)[1].strip().lower()
+            break
+
+if content_type is None:
+    raise SystemExit("public tile content-type header missing")
+if not content_type.startswith(expected):
+    raise SystemExit(
+        f"public tile content-type mismatch: expected prefix {expected}, got {content_type}"
+    )
+PY
+
+  rm -f "$response_file" "$headers_file"
+  smoke_log "public tile content-type verified"
+}
+
 verify_tile_content() {
   local tile_path="$1"
   local expected_b64_path="${2:-}"
@@ -527,6 +626,46 @@ PY
 
   rm -f "$response_file"
   smoke_log "MBTiles schema endpoint verified"
+}
+
+verify_mbtiles_schema_empty_endpoint() {
+  local base_url="$1"
+  local cookie_jar="$2"
+  local file_id="$3"
+
+  smoke_log "verifying MBTiles schema endpoint is empty for file ${file_id}"
+
+  local response_file
+  response_file="$(mktemp)"
+
+  local http_code
+  http_code=$(curl -sS -o "$response_file" -w "%{http_code}" -b "$cookie_jar" \
+    "${base_url}/api/files/${file_id}/schema" || true)
+
+  if [ "$http_code" != "200" ]; then
+    local body
+    body="$(cat "$response_file" 2>/dev/null || true)"
+    rm -f "$response_file"
+    smoke_fail "expected MBTiles schema status 200, got ${http_code}, body=${body}"
+  fi
+
+  python3 - "$response_file" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+layers = data.get("layers")
+if not isinstance(layers, list):
+    raise SystemExit("mbtiles schema validation failed: layers is not an array")
+if len(layers) != 0:
+    raise SystemExit(f"mbtiles schema validation failed: expected empty layers, got {len(layers)}")
+PY
+
+  rm -f "$response_file"
+  smoke_log "MBTiles empty schema endpoint verified"
 }
 
 verify_mbtiles_feature_properties_rejected() {

--- a/scripts/smoke/smoke-binary.sh
+++ b/scripts/smoke/smoke-binary.sh
@@ -10,6 +10,8 @@ PORT="${SMOKE_PORT:-3000}"
 FIXTURE_PATH="${SMOKE_FIXTURE:-frontend/tests/fixtures/sample.geojson}"
 MBTILES_FIXTURE_PATH="${SMOKE_MBTILES_FIXTURE:-testdata/monaco_roads.mbtiles}"
 MBTILES_EXPECTED_FORMAT="${SMOKE_MBTILES_EXPECTED_FORMAT:-mvt}"
+MBTILES_PNG_FIXTURE_PATH="${SMOKE_MBTILES_PNG_FIXTURE:-testdata/sample_png.mbtiles}"
+MBTILES_PNG_EXPECTED_FORMAT="${SMOKE_MBTILES_PNG_EXPECTED_FORMAT:-png}"
 OVERSIZE_FIXTURE_PATH="${SMOKE_OVERSIZE_FIXTURE:-frontend/tests/fixtures/roads.zip}"
 OVERSIZE_LIMIT_MB="${SMOKE_OVERSIZE_LIMIT_MB:-1}"
 CRS_UPDATE_INPUT="${SMOKE_CRS_UPDATE_INPUT:-urn:ogc:def:crs:EPSG::4490}"
@@ -29,6 +31,8 @@ Options:
   --fixture <path>      Test file to upload (default: frontend/tests/fixtures/sample.geojson)
   --mbtiles-fixture <path> MBTiles test file (default: testdata/monaco_roads.mbtiles)
   --mbtiles-format <value> Expected MBTiles tileFormat (default: mvt)
+  --mbtiles-png-fixture <path> PNG MBTiles test file (default: testdata/sample_png.mbtiles)
+  --mbtiles-png-format <value> Expected PNG MBTiles tileFormat (default: png)
   --oversize-fixture <path>  Oversize test file (default: frontend/tests/fixtures/roads.zip)
   --oversize-limit-mb <n>    Temporary upload size limit for oversize check (default: 1)
   --crs-update-input <value> CRS value sent to PUT /api/files/:id/crs
@@ -42,6 +46,8 @@ Environment:
   SMOKE_FIXTURE         Default fixture path
   SMOKE_MBTILES_FIXTURE MBTiles test file path
   SMOKE_MBTILES_EXPECTED_FORMAT Expected MBTiles tileFormat
+  SMOKE_MBTILES_PNG_FIXTURE PNG MBTiles test file path
+  SMOKE_MBTILES_PNG_EXPECTED_FORMAT Expected PNG MBTiles tileFormat
   SMOKE_OVERSIZE_FIXTURE Oversize test file path
   SMOKE_OVERSIZE_LIMIT_MB Temporary upload size limit for oversize check
   SMOKE_CRS_UPDATE_INPUT CRS value sent to PUT /api/files/:id/crs
@@ -61,6 +67,8 @@ while [[ $# -gt 0 ]]; do
     --fixture) FIXTURE_PATH="$2"; shift 2 ;;
     --mbtiles-fixture) MBTILES_FIXTURE_PATH="$2"; shift 2 ;;
     --mbtiles-format) MBTILES_EXPECTED_FORMAT="$2"; shift 2 ;;
+    --mbtiles-png-fixture) MBTILES_PNG_FIXTURE_PATH="$2"; shift 2 ;;
+    --mbtiles-png-format) MBTILES_PNG_EXPECTED_FORMAT="$2"; shift 2 ;;
     --oversize-fixture) OVERSIZE_FIXTURE_PATH="$2"; shift 2 ;;
     --oversize-limit-mb) OVERSIZE_LIMIT_MB="$2"; shift 2 ;;
     --crs-update-input) CRS_UPDATE_INPUT="$2"; shift 2 ;;
@@ -87,6 +95,10 @@ fi
 
 if [ ! -f "$MBTILES_FIXTURE_PATH" ]; then
   smoke_fail "mbtiles fixture not found: ${MBTILES_FIXTURE_PATH}"
+fi
+
+if [ ! -f "$MBTILES_PNG_FIXTURE_PATH" ]; then
+  smoke_fail "mbtiles png fixture not found: ${MBTILES_PNG_FIXTURE_PATH}"
 fi
 
 if [ ! -f "$OVERSIZE_FIXTURE_PATH" ]; then
@@ -154,7 +166,7 @@ smoke_log "published with slug: ${SLUG}"
 get_public_tile "$BASE_URL" "$SLUG" 0 0 0 "$PUBLIC_TILE_OUT"
 
 MBTILES_FILE_ID=$(upload_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FIXTURE_PATH")
-smoke_log "uploaded MBTiles file: ${MBTILES_FILE_ID}"
+smoke_log "uploaded MBTiles(MVT) file: ${MBTILES_FILE_ID}"
 
 wait_for_status "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID" ready
 verify_mbtiles_preview_meta "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID" "$MBTILES_EXPECTED_FORMAT"
@@ -162,8 +174,22 @@ verify_mbtiles_schema_endpoint "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID"
 verify_mbtiles_feature_properties_rejected "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID"
 
 MBTILES_SLUG=$(publish_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID")
-smoke_log "published MBTiles with slug: ${MBTILES_SLUG}"
+smoke_log "published MBTiles(MVT) with slug: ${MBTILES_SLUG}"
 verify_public_tile_meta_format "$BASE_URL" "$MBTILES_SLUG" "$MBTILES_EXPECTED_FORMAT"
+
+MBTILES_PNG_FILE_ID=$(upload_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FIXTURE_PATH")
+smoke_log "uploaded MBTiles(PNG) file: ${MBTILES_PNG_FILE_ID}"
+
+wait_for_status "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID" ready
+verify_mbtiles_preview_meta "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID" "$MBTILES_PNG_EXPECTED_FORMAT"
+verify_mbtiles_schema_empty_endpoint "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID"
+verify_mbtiles_feature_properties_rejected "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID"
+verify_private_tile_content_type "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID" "image/png"
+
+MBTILES_PNG_SLUG=$(publish_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID")
+smoke_log "published MBTiles(PNG) with slug: ${MBTILES_PNG_SLUG}"
+verify_public_tile_meta_format "$BASE_URL" "$MBTILES_PNG_SLUG" "$MBTILES_PNG_EXPECTED_FORMAT"
+verify_public_tile_content_type "$BASE_URL" "$MBTILES_PNG_SLUG" "image/png"
 
 oversize_bytes=$(wc -c < "$OVERSIZE_FIXTURE_PATH" | tr -d ' ')
 oversize_limit_bytes=$((OVERSIZE_LIMIT_MB * 1024 * 1024))

--- a/scripts/smoke/smoke-docker.sh
+++ b/scripts/smoke/smoke-docker.sh
@@ -10,6 +10,8 @@ PORT="${SMOKE_PORT:-3000}"
 FIXTURE_PATH="${SMOKE_FIXTURE:-frontend/tests/fixtures/sample.geojson}"
 MBTILES_FIXTURE_PATH="${SMOKE_MBTILES_FIXTURE:-testdata/monaco_roads.mbtiles}"
 MBTILES_EXPECTED_FORMAT="${SMOKE_MBTILES_EXPECTED_FORMAT:-mvt}"
+MBTILES_PNG_FIXTURE_PATH="${SMOKE_MBTILES_PNG_FIXTURE:-testdata/sample_png.mbtiles}"
+MBTILES_PNG_EXPECTED_FORMAT="${SMOKE_MBTILES_PNG_EXPECTED_FORMAT:-png}"
 OVERSIZE_FIXTURE_PATH="${SMOKE_OVERSIZE_FIXTURE:-frontend/tests/fixtures/roads.zip}"
 OVERSIZE_LIMIT_MB="${SMOKE_OVERSIZE_LIMIT_MB:-1}"
 CRS_UPDATE_INPUT="${SMOKE_CRS_UPDATE_INPUT:-urn:ogc:def:crs:EPSG::4490}"
@@ -29,6 +31,8 @@ Options:
   --fixture <path>      Test file to upload (default: frontend/tests/fixtures/sample.geojson)
   --mbtiles-fixture <path> MBTiles test file (default: testdata/monaco_roads.mbtiles)
   --mbtiles-format <value> Expected MBTiles tileFormat (default: mvt)
+  --mbtiles-png-fixture <path> PNG MBTiles test file (default: testdata/sample_png.mbtiles)
+  --mbtiles-png-format <value> Expected PNG MBTiles tileFormat (default: png)
   --oversize-fixture <path>  Oversize test file (default: frontend/tests/fixtures/roads.zip)
   --oversize-limit-mb <n>    Temporary upload size limit for oversize check (default: 1)
   --crs-update-input <value> CRS value sent to PUT /api/files/:id/crs
@@ -42,6 +46,8 @@ Environment:
   SMOKE_FIXTURE         Default fixture path
   SMOKE_MBTILES_FIXTURE MBTiles test file path
   SMOKE_MBTILES_EXPECTED_FORMAT Expected MBTiles tileFormat
+  SMOKE_MBTILES_PNG_FIXTURE PNG MBTiles test file path
+  SMOKE_MBTILES_PNG_EXPECTED_FORMAT Expected PNG MBTiles tileFormat
   SMOKE_OVERSIZE_FIXTURE Oversize test file path
   SMOKE_OVERSIZE_LIMIT_MB Temporary upload size limit for oversize check
   SMOKE_CRS_UPDATE_INPUT CRS value sent to PUT /api/files/:id/crs
@@ -61,6 +67,8 @@ while [[ $# -gt 0 ]]; do
     --fixture) FIXTURE_PATH="$2"; shift 2 ;;
     --mbtiles-fixture) MBTILES_FIXTURE_PATH="$2"; shift 2 ;;
     --mbtiles-format) MBTILES_EXPECTED_FORMAT="$2"; shift 2 ;;
+    --mbtiles-png-fixture) MBTILES_PNG_FIXTURE_PATH="$2"; shift 2 ;;
+    --mbtiles-png-format) MBTILES_PNG_EXPECTED_FORMAT="$2"; shift 2 ;;
     --oversize-fixture) OVERSIZE_FIXTURE_PATH="$2"; shift 2 ;;
     --oversize-limit-mb) OVERSIZE_LIMIT_MB="$2"; shift 2 ;;
     --crs-update-input) CRS_UPDATE_INPUT="$2"; shift 2 ;;
@@ -83,6 +91,10 @@ fi
 
 if [ ! -f "$MBTILES_FIXTURE_PATH" ]; then
   smoke_fail "mbtiles fixture not found: ${MBTILES_FIXTURE_PATH}"
+fi
+
+if [ ! -f "$MBTILES_PNG_FIXTURE_PATH" ]; then
+  smoke_fail "mbtiles png fixture not found: ${MBTILES_PNG_FIXTURE_PATH}"
 fi
 
 if [ ! -f "$OVERSIZE_FIXTURE_PATH" ]; then
@@ -155,7 +167,7 @@ smoke_log "published with slug: ${SLUG}"
 get_public_tile "$BASE_URL" "$SLUG" 0 0 0 "$PUBLIC_TILE_OUT"
 
 MBTILES_FILE_ID=$(upload_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FIXTURE_PATH")
-smoke_log "uploaded MBTiles file: ${MBTILES_FILE_ID}"
+smoke_log "uploaded MBTiles(MVT) file: ${MBTILES_FILE_ID}"
 
 wait_for_status "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID" ready
 verify_mbtiles_preview_meta "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID" "$MBTILES_EXPECTED_FORMAT"
@@ -163,8 +175,22 @@ verify_mbtiles_schema_endpoint "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID"
 verify_mbtiles_feature_properties_rejected "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID"
 
 MBTILES_SLUG=$(publish_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_FILE_ID")
-smoke_log "published MBTiles with slug: ${MBTILES_SLUG}"
+smoke_log "published MBTiles(MVT) with slug: ${MBTILES_SLUG}"
 verify_public_tile_meta_format "$BASE_URL" "$MBTILES_SLUG" "$MBTILES_EXPECTED_FORMAT"
+
+MBTILES_PNG_FILE_ID=$(upload_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FIXTURE_PATH")
+smoke_log "uploaded MBTiles(PNG) file: ${MBTILES_PNG_FILE_ID}"
+
+wait_for_status "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID" ready
+verify_mbtiles_preview_meta "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID" "$MBTILES_PNG_EXPECTED_FORMAT"
+verify_mbtiles_schema_empty_endpoint "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID"
+verify_mbtiles_feature_properties_rejected "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID"
+verify_private_tile_content_type "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID" "image/png"
+
+MBTILES_PNG_SLUG=$(publish_file "$BASE_URL" "$COOKIE_JAR" "$MBTILES_PNG_FILE_ID")
+smoke_log "published MBTiles(PNG) with slug: ${MBTILES_PNG_SLUG}"
+verify_public_tile_meta_format "$BASE_URL" "$MBTILES_PNG_SLUG" "$MBTILES_PNG_EXPECTED_FORMAT"
+verify_public_tile_content_type "$BASE_URL" "$MBTILES_PNG_SLUG" "image/png"
 
 oversize_bytes=$(wc -c < "$OVERSIZE_FIXTURE_PATH" | tr -d ' ')
 oversize_limit_bytes=$((OVERSIZE_LIMIT_MB * 1024 * 1024))


### PR DESCRIPTION
## Summary
- extend smoke scripts to cover MBTiles PNG in addition to existing MBTiles MVT flow
- add assertions for PNG-specific behavior: schema `layers=[]` and private/public tile `Content-Type: image/png`
- document new smoke options and scenarios in scripts/smoke/README.md
- record execution + verification in docs/dev/todo.md (S22)

## Validation
- bash -n scripts/smoke/lib/common.sh scripts/smoke/smoke-binary.sh scripts/smoke/smoke-docker.sh
- bash scripts/smoke/smoke-binary.sh --binary ./target/debug/backend --port 3331 --expected-b64 /tmp/nonexistent-smoke-expected.b64
- docker build -t mapflow-smoke:mbtiles-png .
- bash scripts/smoke/smoke-docker.sh --image mapflow-smoke:mbtiles-png --port 3332 --expected-b64 /tmp/nonexistent-smoke-expected.b64
- bash scripts/ci/lint_behaviors_refs.sh
- pre-commit hooks (fmt/clippy/backend tests/frontend unit)
- pre-push full suite (backend tests + frontend unit + frontend e2e)
