### PR TITLE
feat(release): add Linux .deb packaging + install smoke validation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,7 @@ jobs:
       release_tag: ${{ steps.meta.outputs.release_tag }}
       release_name: ${{ steps.meta.outputs.release_name }}
       release_version: ${{ steps.meta.outputs.release_version }}
+      deb_version: ${{ steps.meta.outputs.deb_version }}
       stamp: ${{ steps.meta.outputs.stamp }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
       owner_lc: ${{ steps.meta.outputs.owner_lc }}
@@ -37,6 +38,7 @@ jobs:
           echo "owner_lc=${owner_lc}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
           echo "release_version=${release_tag}" >> "$GITHUB_OUTPUT"
+          echo "deb_version=0.0.0~nightly.${stamp}+${short_sha}.r${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "release_name=Nightly ${stamp} (${short_sha})" >> "$GITHUB_OUTPUT"
 
   verify:
@@ -233,6 +235,45 @@ jobs:
             "${bundle_binary}" \
             "release-assets"
 
+      - name: Package deb (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/release/package_deb.sh \
+            "${{ needs.meta.outputs.deb_version }}" \
+            "${{ matrix.artifact_id }}" \
+            "target/${{ matrix.rust_target }}/release/backend" \
+            "release-assets"
+
+      - name: Verify deb package (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb_path="$(ls release-assets/*.deb | head -n 1)"
+          dpkg-deb --info "${deb_path}" >/dev/null
+          contents="$(dpkg-deb --contents "${deb_path}")"
+          grep -q "./usr/bin/mapflow" <<<"${contents}"
+          grep -q "./usr/share/mapflow/spatial-extension-manifest.json" <<<"${contents}"
+          grep -q "./usr/share/doc/mapflow/README.md" <<<"${contents}"
+          grep -q "./usr/share/doc/mapflow/LICENSE" <<<"${contents}"
+          grep -q "./usr/share/doc/mapflow/NOTICE" <<<"${contents}"
+
+      - name: Smoke test installed deb (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb_path="$(ls release-assets/*.deb | head -n 1)"
+          cleanup() {
+            sudo dpkg -r mapflow >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          sudo dpkg -i "${deb_path}"
+          /usr/bin/mapflow --version
+          bash scripts/smoke/smoke-binary.sh --binary /usr/bin/mapflow --port 3317
+
       - name: Upload binary bundle
         uses: actions/upload-artifact@v7
         with:
@@ -240,6 +281,7 @@ jobs:
           path: |
             release-assets/*.tar.gz
             release-assets/*.zip
+            release-assets/*.deb
 
   docker_build:
     needs:
@@ -403,3 +445,4 @@ jobs:
           files: |
             release-assets/**/*.tar.gz
             release-assets/**/*.zip
+            release-assets/**/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,45 @@ jobs:
             "${bundle_binary}" \
             "release-assets"
 
+      - name: Package deb (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/release/package_deb.sh \
+            "${{ github.ref_name }}" \
+            "${{ matrix.artifact_id }}" \
+            "target/${{ matrix.rust_target }}/release/backend" \
+            "release-assets"
+
+      - name: Verify deb package (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb_path="$(ls release-assets/*.deb | head -n 1)"
+          dpkg-deb --info "${deb_path}" >/dev/null
+          contents="$(dpkg-deb --contents "${deb_path}")"
+          grep -q "./usr/bin/mapflow" <<<"${contents}"
+          grep -q "./usr/share/mapflow/spatial-extension-manifest.json" <<<"${contents}"
+          grep -q "./usr/share/doc/mapflow/README.md" <<<"${contents}"
+          grep -q "./usr/share/doc/mapflow/LICENSE" <<<"${contents}"
+          grep -q "./usr/share/doc/mapflow/NOTICE" <<<"${contents}"
+
+      - name: Smoke test installed deb (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb_path="$(ls release-assets/*.deb | head -n 1)"
+          cleanup() {
+            sudo dpkg -r mapflow >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          sudo dpkg -i "${deb_path}"
+          /usr/bin/mapflow --version
+          bash scripts/smoke/smoke-binary.sh --binary /usr/bin/mapflow --port 3317
+
       - name: Upload binary bundle
         uses: actions/upload-artifact@v7
         with:
@@ -211,6 +250,7 @@ jobs:
           path: |
             release-assets/*.tar.gz
             release-assets/*.zip
+            release-assets/*.deb
 
   docker_build:
     needs: docker_smoke
@@ -357,3 +397,4 @@ jobs:
           files: |
             release-assets/**/*.tar.gz
             release-assets/**/*.zip
+            release-assets/**/*.deb

--- a/docs/dev/behaviors.md
+++ b/docs/dev/behaviors.md
@@ -90,8 +90,9 @@
 | E2E-009 | 认证流程 | 首次访问 → 设置 → 登录 → 使用 → 登出 | 状态正确 | `frontend/tests/auth.spec.js` | E2E | P0 |
 | E2E-010 | 发布流程 | 上传文件 → ready → 点击发布 → 自定义 slug → 确认 → 复制公开地址 → 无需认证访问瓦片 | 端到端流程成功 | `frontend/tests/publish.spec.js` | E2E | P0 |
 | CI-001 | 冒烟测试 | 构建 Docker/二进制 → 上传 GeoJSON → 等待 ready → 获取瓦片 → 发布 → 公开瓦片。关键 HTTP 调用具备重试能力（降低网络抖动误报） | 与 testdata/smoke/expected_sample_z0_x0_y0.mvt.base64 比较字节 | `scripts/smoke/smoke-docker.sh` / `scripts/smoke/smoke-binary.sh` (release/nightly only) | Integration | P1 |
-| CI-002 | Nightly 发布 | Nightly 工作流每日触发，先执行 verify + smoke，再发布二进制 bundle 和 GHCR nightly 镜像标签 | 生成 prerelease，包含 Linux/macOS bundle；镜像标签包含 nightly、日期、sha | `.github/workflows/nightly.yml` | Delivery | P1 |
-| CI-003 | Stable 发布 | `v*` tag 工作流先执行 verify + smoke，再发布二进制 bundle 和 GHCR stable 镜像标签 | 生成 release，包含 Linux/macOS bundle；镜像标签包含版本号和 latest | `.github/workflows/release.yml` | Delivery | P1 |
+| CI-002 | Nightly 发布 | Nightly 工作流每日触发，先执行 verify + smoke，再发布二进制 bundle、Linux `.deb`（amd64/arm64）和 GHCR nightly 镜像标签 | 生成 prerelease，包含 Linux/macOS bundle + Linux `.deb`；镜像标签包含 nightly、日期、sha | `.github/workflows/nightly.yml` | Delivery | P1 |
+| CI-003 | Stable 发布 | `v*` tag 工作流先执行 verify + smoke，再发布二进制 bundle、Linux `.deb`（amd64/arm64）和 GHCR stable 镜像标签 | 生成 release，包含 Linux/macOS bundle + Linux `.deb`；镜像标签包含版本号和 latest | `.github/workflows/release.yml` | Delivery | P1 |
+| CI-005 | `.deb` 安装验证 | Linux 发布流程对生成的 `.deb` 执行安装校验（`dpkg -i` + `mapflow --version`）并复用 binary smoke 验证安装后行为 | 安装成功且 `scripts/smoke/smoke-binary.sh --binary /usr/bin/mapflow` 通过 | `.github/workflows/nightly.yml` `.github/workflows/release.yml` | Delivery | P1 |
 | CI-004 | 离线扩展打包 | 发布流程按目标平台下载 DuckDB spatial extension；Docker 镜像写入 `/app/extensions/`，二进制 bundle 在构建时内嵌 extension | 镜像内存在 `/app/extensions/spatial.duckdb_extension`；bundle 仅含可执行文件但可离线启动并成功加载 spatial | `scripts/release/spatial_extension_artifact.sh` | Delivery | P1 |
 | OSM-001 | 瓦片生成（lines） | OSM sf_lines（20,898 道路特征）数据集生成正确瓦片（z=0,10,14 各 5 个样本） | 特征计数匹配 golden 配置 | `cargo test test_tile_golden_osm_lines_samples` | Integration | P1 |
 | OSM-002 | 瓦片生成（points） | OSM sf_points（交通信号灯、地点）数据集生成正确瓦片（z=0,10,14 各 5 个样本） | 特征计数匹配 golden 配置 | `cargo test test_tile_golden_osm_points_samples` | Integration | P1 |

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -47,5 +47,6 @@ Axum 0.8, axum-login, tower-sessions, DuckDB, OpenLayers
 
 - Stable：`v*` tag 触发，发布 GHCR 多架构镜像与二进制 bundle 资产
 - Nightly：每日 UTC 02:00 自动触发（也支持手动触发），发布 prerelease 与 nightly 镜像标签
+- Linux 额外发布 `.deb`（amd64/arm64）用于系统安装分发（Phase 1 不含 systemd 集成）
 - 二进制发布产物内嵌 `spatial.duckdb_extension`（按目标平台编译时注入），支持离线启动
 - Windows 发布包仅暴露 desktop 入口（`mapflow-desktop.exe`），console 入口保留给开发/CI

--- a/scripts/release/package_deb.sh
+++ b/scripts/release/package_deb.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <version> <artifact-id> <binary-path> <output-dir>" >&2
+  exit 1
+fi
+
+version_raw="$1"
+artifact_id="$2"
+binary_path="$3"
+output_dir="$4"
+
+if [ ! -f "$binary_path" ]; then
+  echo "binary not found: $binary_path" >&2
+  exit 1
+fi
+
+case "$artifact_id" in
+  linux-amd64) deb_arch="amd64" ;;
+  linux-arm64) deb_arch="arm64" ;;
+  *)
+    echo "unsupported artifact-id for deb packaging: $artifact_id" >&2
+    exit 1
+    ;;
+esac
+
+normalize_version() {
+  local v="$1"
+
+  # Normalize stable tag like v0.1.2 -> 0.1.2
+  if [[ "$v" =~ ^v[0-9] ]]; then
+    v="${v#v}"
+  fi
+
+  if [[ ! "$v" =~ ^[A-Za-z0-9.+:~-]+$ ]]; then
+    echo "invalid deb version: ${v}" >&2
+    exit 1
+  fi
+
+  printf '%s' "$v"
+}
+
+deb_version="$(normalize_version "$version_raw")"
+package_name="mapflow"
+deb_name="${package_name}_${deb_version}-1_${deb_arch}.deb"
+build_root="$(mktemp -d)"
+package_root="${build_root}/${package_name}"
+trap 'rm -rf "${build_root}"' EXIT
+
+mkdir -p \
+  "${package_root}/DEBIAN" \
+  "${package_root}/usr/bin" \
+  "${package_root}/usr/share/mapflow" \
+  "${package_root}/usr/share/doc/${package_name}"
+
+cp "$binary_path" "${package_root}/usr/bin/mapflow"
+chmod 0755 "${package_root}/usr/bin/mapflow"
+cp backend/extensions/spatial-extension-manifest.json "${package_root}/usr/share/mapflow/spatial-extension-manifest.json"
+cp README.md "${package_root}/usr/share/doc/${package_name}/README.md"
+cp LICENSE "${package_root}/usr/share/doc/${package_name}/LICENSE"
+cp NOTICE "${package_root}/usr/share/doc/${package_name}/NOTICE"
+
+cat > "${package_root}/DEBIAN/control" <<EOF
+Package: ${package_name}
+Version: ${deb_version}-1
+Section: utils
+Priority: optional
+Architecture: ${deb_arch}
+Maintainer: MapFlow Maintainers <maintainers@mapflow.invalid>
+Description: MapFlow binary distribution
+ Self-contained MapFlow server binary package.
+EOF
+
+mkdir -p "$output_dir"
+archive_path="${output_dir}/${deb_name}"
+dpkg-deb --build --root-owner-group "${package_root}" "${archive_path}" >/dev/null
+
+echo "archive_path=${archive_path}"


### PR DESCRIPTION
## Summary
- add `scripts/release/package_deb.sh` to produce Linux `.deb` artifacts from release binaries
- extend release/nightly workflows to package `.deb` for Linux matrix targets (`amd64`, `arm64`)
- add `.deb` verification in CI: package metadata/contents check, `dpkg -i`, `mapflow --version`, and smoke test via installed binary (`/usr/bin/mapflow`)
- upload `.deb` files to GitHub release assets (stable + nightly)
- update docs/contracts to reflect Linux `.deb` delivery and installation validation

## Why
Current delivery only publishes `.tar.gz`/`.zip` bundles. This adds a first-phase Debian package distribution path with installation-level validation while keeping existing runtime smoke coverage unchanged.

## Validation
- pre-commit hooks passed (fmt/clippy/tests/unit checks)
- pre-push hooks passed, including full backend tests and frontend E2E suite
